### PR TITLE
Gyro Roll and Gyro Rotation3d get methods

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -5,6 +5,7 @@ import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;


### PR DESCRIPTION
- fix documentation
- create method for getting roll
- if robot is not real, return empty Rotation2d for roll and pitch. In the future, perhaps this could also use an accumulator according to a 3d environment, but that would require a lot of work, so this is good for now.
- add method for getting a rotation3d of the gyro. Instead of creating it with the already existing yaw/pitch/roll methods, creates it anew from the radians reported by gyro. This only creates one call to the imu, whereas creating it with existing methods would create three calls. I'm not sure how significant this is for performance, but it seems alright.