### PR TITLE
[DRAFT] Fix for TalonFX PID wrapping

### DIFF
--- a/src/main/java/swervelib/motors/TalonFXSwerve.java
+++ b/src/main/java/swervelib/motors/TalonFXSwerve.java
@@ -289,7 +289,7 @@ public class TalonFXSwerve extends SwerveMotor
   public double convertToNativeSensorUnits(double setpoint)
   {
     setpoint = isDriveMotor ? 
-               (setpoint * .1) : 
+               setpoint * .1 : 
                placeInAppropriate0To360Scope(getRawPosition(), setpoint);
     return setpoint / positionConversionFactor;
   }
@@ -353,9 +353,7 @@ public class TalonFXSwerve extends SwerveMotor
    */
   public double getRawPosition()
   {
-    return isDriveMotor ? 
-          motor.getSelectedSensorPosition() * positionConversionFactor : 
-          (motor.getSelectedSensorPosition() * positionConversionFactor) % 360;
+    return motor.getSelectedSensorPosition() * positionConversionFactor;
   }
 
   /**


### PR DESCRIPTION
Draft for fixing TalonFX wrapping (if it needs to be fixed).
- add placeInAppropriate0To360Scope from BaseTalonSwerve code. Should take the current true position of the encoder in units of degrees, then places the setpoint in the appropriate scope.
- the method could probably be optimized since it uses a while statement
- revise getPosition() to use modulus with 360, since a few methods externally rely on position being within the first rotation. Not sure if this is completely necessary since some of the methods just use .getCos and .getSin for a Rotation2d, including the .optimize which just rotates the angles to find the difference.