### PR TITLE
Fix Rotation3d and Roll Getters

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -337,7 +337,7 @@ public class SwerveDrive
     {
       double[] ypr = new double[3];
       imu.getYawPitchRoll(ypr);
-      return Rotation2d.fromDegrees(swerveDriveConfiguration.invertedIMU ? 360 - ypr[1] : ypr[1]);
+      return Rotation2d.fromDegrees(swerveDriveConfiguration.invertedIMU ? 360 - ypr[2] : ypr[2]);
     } else
     {
       return new Rotation2d();


### PR DESCRIPTION
- Rotation3d initializes with roll, pitch, yaw, not yaw, pitch, roll (I'm not sure why exactly). Changed to fit that.
- also fix getRoll to return roll `ypr[2]` instead of pitch