### PR TITLE
Fix Issues with "none" Type Absolute Encoder

### DIFF
--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -90,12 +90,12 @@ public class SwerveModule
     {
       absoluteEncoder.factoryDefault();
       absoluteEncoder.configure(moduleConfiguration.absoluteEncoderInverted);
-      angleMotor.configureIntegratedEncoder(
-          moduleConfiguration.getPositionEncoderConversion(false));
       angleMotor.setPosition(absoluteEncoder.getAbsolutePosition() - angleOffset);
     }
 
     // Config angle motor/controller
+    angleMotor.configureIntegratedEncoder(
+      moduleConfiguration.getPositionEncoderConversion(false));
     angleMotor.configurePIDF(moduleConfiguration.anglePIDF);
     angleMotor.configurePIDWrapping(-180, 180);
     angleMotor.setInverted(moduleConfiguration.angleMotorInverted);
@@ -237,13 +237,18 @@ public class SwerveModule
    */
   public double getAbsolutePosition()
   {
-    double angle = absoluteEncoder.getAbsolutePosition();
-    if (absoluteEncoder.readingError)
+    if (absoluteEncoder != null)
     {
-      angle = getRelativePosition();
+      double angle = absoluteEncoder.getAbsolutePosition();
+      if (absoluteEncoder.readingError)
+      {
+        angle = getRelativePosition();
+      }
+
+      return angle;
     }
 
-    return angle;
+    return getRelativePosition();
   }
 
   /**

--- a/src/main/java/swervelib/parser/json/DeviceJson.java
+++ b/src/main/java/swervelib/parser/json/DeviceJson.java
@@ -123,7 +123,8 @@ public class DeviceJson
     {
       case "sparkmax":
         return new SparkMaxEncoderSwerve(motor);
-      case "none":
+      case "falcon":
+      case "talonfx":
         return null;
     }
     throw new RuntimeException(


### PR DESCRIPTION
When you initialize the encoder with "none" in the JSON, errors are thrown. In the `DeviceJson.java`, the check for "none" doesn't work because the type is of type motor, not of absolute encoder. Fix is to check if motor is talonfx or falcon (since that's not supported anyways for abs encoder). This means "none" isn't supported on sparkmax.

Also because of a telemetry call with SmartDashboard, the `getAbsolutePosition()` method is called, so protection is put into place for if absolute encoder doesn't exist.

Angle motor `positionConversionFactor` also still needs to be set if there's no absolute encoder.