### PR TITLE
CANAndCoderSwerve addition

### DIFF
--- a/src/main/java/swervelib/encoders/CanAndCoderSwerve.java
+++ b/src/main/java/swervelib/encoders/CanAndCoderSwerve.java
@@ -1,0 +1,78 @@
+package swervelib.encoders;
+
+import com.revrobotics.AbsoluteEncoder;
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.SparkMaxAbsoluteEncoder.Type;
+import swervelib.motors.SwerveMotor;
+
+/**
+ * SparkMax absolute encoder, attached through the data port.
+ */
+public class CanAndCoderSwerve extends SwerveAbsoluteEncoder {
+
+  /**
+   * The {@link AbsoluteEncoder} representing the duty cycle encoder attached to
+   * the SparkMax.
+   */
+  public AbsoluteEncoder encoder;
+
+  /**
+   * Create the {@link AbsoluteEncoder} object as a duty cycle. from the
+   * {@link CANSparkMax} motor.
+   *
+   * @param motor Motor to create the encoder from.
+   */
+  public CanAndCoderSwerve(SwerveMotor motor) {
+    if (motor.getMotor() instanceof CANSparkMax) {
+      encoder = ((CANSparkMax) motor.getMotor()).getAbsoluteEncoder(Type.kDutyCycle);
+    } else {
+      throw new RuntimeException("Motor given to instantiate SparkMaxEncoder is not a CANSparkMax");
+    }
+  }
+
+  /**
+   * Reset the encoder to factory defaults.
+   */
+  @Override
+  public void factoryDefault() {
+    // Do nothing
+  }
+
+  /**
+   * Clear sticky faults on the encoder.
+   */
+  @Override
+  public void clearStickyFaults() {
+    // Do nothing
+  }
+
+  /**
+   * Configure the absolute encoder to read from [0, 360) per second.
+   *
+   * @param inverted Whether the encoder is inverted.
+   */
+  @Override
+  public void configure(boolean inverted) {
+    encoder.setInverted(inverted);
+  }
+
+  /**
+   * Get the absolute position of the encoder.
+   *
+   * @return Absolute position in degrees from [0, 360).
+   */
+  @Override
+  public double getAbsolutePosition() {
+    return (encoder.getPosition() * 360);
+  }
+
+  /**
+   * Get the instantiated absolute encoder Object.
+   *
+   * @return Absolute encoder object.
+   */
+  @Override
+  public Object getAbsoluteEncoder() {
+    return encoder;
+  }
+}

--- a/src/main/java/swervelib/motors/SparkMaxSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxSwerve.java
@@ -269,8 +269,12 @@ public class SparkMaxSwerve extends SwerveMotor
    * Save the configurations from flash to EEPROM.
    */
   @Override
-  public void burnFlash()
+  public void burnFlash() 
   {
+    try {
+      Thread.sleep(200);
+    } catch (Exception e) {
+    }
     motor.burnFlash();
   }
 

--- a/src/main/java/swervelib/parser/json/DeviceJson.java
+++ b/src/main/java/swervelib/parser/json/DeviceJson.java
@@ -4,6 +4,7 @@ import com.revrobotics.SparkMaxRelativeEncoder.Type;
 import edu.wpi.first.wpilibj.SerialPort.Port;
 import swervelib.encoders.AnalogAbsoluteEncoderSwerve;
 import swervelib.encoders.CANCoderSwerve;
+import swervelib.encoders.CanAndCoderSwerve;
 import swervelib.encoders.SparkMaxEncoderSwerve;
 import swervelib.encoders.SwerveAbsoluteEncoder;
 import swervelib.imu.ADIS16448Swerve;
@@ -44,14 +45,15 @@ public class DeviceJson
    *
    * @return {@link SwerveAbsoluteEncoder} given.
    */
-  public SwerveAbsoluteEncoder createEncoder()
-  {
-    switch (type)
+  public SwerveAbsoluteEncoder createEncoder(SwerveMotor motor) {
+    switch (type) 
     {
       case "none":
       case "integrated":
       case "attached":
         return null;
+      case "canandcoder":
+        return new CanAndCoderSwerve(motor);
       case "thrifty":
       case "throughbore":
       case "dutycycle":

--- a/src/main/java/swervelib/parser/json/ModuleJson.java
+++ b/src/main/java/swervelib/parser/json/ModuleJson.java
@@ -66,7 +66,7 @@ public class ModuleJson
       String name)
   {
     SwerveMotor           angleMotor = angle.createMotor(false);
-    SwerveAbsoluteEncoder absEncoder = encoder.createEncoder();
+    SwerveAbsoluteEncoder absEncoder = encoder.createEncoder(angleMotor);
 
     // If the absolute encoder is attached.
     if (absEncoder == null)
@@ -90,7 +90,7 @@ public class ModuleJson
         inverted.drive,
         inverted.angle,
         angleEncoderPulsePerRevolution == 0 ? physicalCharacteristics.angleEncoderPulsePerRotation
-                                            : angleEncoderPulsePerRevolution,
+            : angleEncoderPulsePerRevolution,
         name.replaceAll("\\.json", ""));
   }
 }


### PR DESCRIPTION
This adds the CANandCoderSwerve absolution encoder type, adds an option for using it in the config files and sets a small delay in the burnFlash method to fix a config issue we had.