### PR TITLE
Add Setting the Absolute Encoder Offset

### DIFF
--- a/src/main/java/swervelib/encoders/AnalogAbsoluteEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/AnalogAbsoluteEncoderSwerve.java
@@ -89,4 +89,13 @@ public class AnalogAbsoluteEncoderSwerve extends SwerveAbsoluteEncoder
   {
     return encoder;
   }
+
+  /*
+   * Cannot Set the offset of an Analog absolute Encoder
+   */
+  @Override
+  public void setAbsoluteEncoderOffset(double offset)
+  {
+    //Do Nothing
+  }
 }

--- a/src/main/java/swervelib/encoders/CANCoderSwerve.java
+++ b/src/main/java/swervelib/encoders/CANCoderSwerve.java
@@ -137,4 +137,13 @@ public class CANCoderSwerve extends SwerveAbsoluteEncoder
   {
     return encoder;
   }
+
+  /*
+   * Sets the Absolute Encoder Offset inside of the CANcoder's Memory
+   */
+  @Override
+  public void setAbsoluteEncoderOffset(double offset)
+  {
+    encoder.configMagnetOffset(offset);
+  }
 }

--- a/src/main/java/swervelib/encoders/CanAndCoderSwerve.java
+++ b/src/main/java/swervelib/encoders/CanAndCoderSwerve.java
@@ -77,4 +77,13 @@ public class CanAndCoderSwerve extends SwerveAbsoluteEncoder
   {
     return encoder;
   }
+
+  /*
+   * Cannot Set the offset of the CanAndCoder
+   */
+  @Override
+  public void setAbsoluteEncoderOffset(double offset)
+  {
+    //CanAndCoder does not support Absolute Offset Changing
+  }
 }

--- a/src/main/java/swervelib/encoders/PWMDutyCycleEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/PWMDutyCycleEncoderSwerve.java
@@ -83,4 +83,13 @@ public class PWMDutyCycleEncoderSwerve extends SwerveAbsoluteEncoder
     // Do nothing
   }
 
+  /*
+   * Sets the Offset of the Encoder in the WPILib Encoder Library
+   */
+  @Override
+  public void setAbsoluteEncoderOffset(double offset)
+  {
+    encoder.setPositionOffset(offset);
+  }
+
 }

--- a/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
@@ -105,4 +105,13 @@ public class SparkMaxEncoderSwerve extends SwerveAbsoluteEncoder
   {
     return encoder;
   }
+
+  /*
+   * Sets the Absolute Encoder Offset inside of the SparkMax's Memory
+   */
+  @Override
+  public void setAbsoluteEncoderOffset(double offset)
+  {
+    encoder.setZeroOffset(offset);
+  }
 }

--- a/src/main/java/swervelib/encoders/SwerveAbsoluteEncoder.java
+++ b/src/main/java/swervelib/encoders/SwerveAbsoluteEncoder.java
@@ -45,4 +45,9 @@ public abstract class SwerveAbsoluteEncoder
    * @return Absolute encoder object.
    */
   public abstract Object getAbsoluteEncoder();
+
+  /**
+   * Sets the Absolute Encoder offset at the Encoder Level
+   */
+  public abstract void setAbsoluteEncoderOffset(double offset);
 }


### PR DESCRIPTION
Add Setting the Absolute Encoder Offset though code.

Supported Encoders

- Attached Sparkmax Alternate Encoder
- CANcoder
- PWMDutyCycle AbsoluteEncoder

Unsupported Encoders
- CanAndCoder
- AnalogEncoder

Analog Encoder could be supported If it was using the [WPILib analog encoder methods ](https://docs.wpilib.org/en/stable/docs/software/hardware-apis/sensors/encoders-software.html), but currently it uses [digital inputs ](https://docs.wpilib.org/en/stable/docs/software/hardware-apis/sensors/digital-inputs-software.html)