### PR TITLE
Fixed: Attached Sparkmax Absolute Encoder Conversion Factor will be changed when configuring the Integrated Encoder

### DIFF
--- a/src/main/java/swervelib/motors/SparkMaxSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxSwerve.java
@@ -201,35 +201,12 @@ public class SparkMaxSwerve extends SwerveMotor
   @Override
   public void configureIntegratedEncoder(double positionConversionFactor)
   {
-    if (absoluteEncoder == null)
-    {
-      configureSparkMax(() -> encoder.setPositionConversionFactor(positionConversionFactor));
-      configureSparkMax(() -> encoder.setVelocityConversionFactor(positionConversionFactor / 60));
+    configureSparkMax(() -> encoder.setPositionConversionFactor(positionConversionFactor));
+    configureSparkMax(() -> encoder.setVelocityConversionFactor(positionConversionFactor / 60));
 
-      // Taken from
-      // https://github.com/frc3512/SwerveBot-2022/blob/9d31afd05df6c630d5acb4ec2cf5d734c9093bf8/src/main/java/frc/lib/util/CANSparkMaxUtil.java#L67
-      configureCANStatusFrames(10, 20, 20, 500, 500);
-    } else
-    {
-      configureSparkMax(() -> {
-        if (absoluteEncoder.getAbsoluteEncoder() instanceof AbsoluteEncoder)
-        {
-          return ((AbsoluteEncoder) absoluteEncoder.getAbsoluteEncoder()).setPositionConversionFactor(positionConversionFactor);
-        } else
-        {
-          return ((SparkMaxAnalogSensor)absoluteEncoder.getAbsoluteEncoder()).setPositionConversionFactor(positionConversionFactor);
-        }
-      });
-      configureSparkMax(() -> {
-        if (absoluteEncoder.getAbsoluteEncoder() instanceof AbsoluteEncoder)
-        {
-          return ((AbsoluteEncoder) absoluteEncoder.getAbsoluteEncoder()).setVelocityConversionFactor(positionConversionFactor / 60);
-        } else
-        {
-          return ((SparkMaxAnalogSensor)absoluteEncoder.getAbsoluteEncoder()).setVelocityConversionFactor(positionConversionFactor / 60);
-        }
-      });
-    }
+    // Taken from
+    // https://github.com/frc3512/SwerveBot-2022/blob/9d31afd05df6c630d5acb4ec2cf5d734c9093bf8/src/main/java/frc/lib/util/CANSparkMaxUtil.java#L67
+    configureCANStatusFrames(10, 20, 20, 500, 500);
   }
 
   /**

--- a/src/main/java/swervelib/parser/json/DeviceJson.java
+++ b/src/main/java/swervelib/parser/json/DeviceJson.java
@@ -65,7 +65,7 @@ public class DeviceJson
         return null;
       case "integrated":
       case "attached":
-        return new SparkMaxEncoderSwerve(motor, 1);
+        return new SparkMaxEncoderSwerve(motor, 360);
       case "sparkmax_analog":
         return new SparkMaxAnalogEncoderSwerve(motor);
       case "canandcoder":


### PR DESCRIPTION
When configuring the integrated encoder it would overwrite the Absolute Encoder Conversion factor which was set in DeviceJson. This should not happen as then the integrated encoder will have the same conversion factor as the absolute encoder.

I also changed the default conversion factor in DeviceJson as 1 wasn't working for us. 