### PR TITLE
Update vendordeps to use current 2024 libraries

### DIFF
--- a/src/main/java/swervelib/motors/SparkMaxBrushedMotorSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxBrushedMotorSwerve.java
@@ -2,8 +2,8 @@ package swervelib.motors;
 
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
-import com.revrobotics.CANSparkMax.IdleMode;
+import com.revrobotics.CANSparkBase.ControlType;
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.CANSparkMaxLowLevel.PeriodicFrame;
 import com.revrobotics.REVLibError;

--- a/src/main/java/swervelib/motors/SparkMaxSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxSwerve.java
@@ -2,8 +2,8 @@ package swervelib.motors;
 
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
-import com.revrobotics.CANSparkMax.IdleMode;
+import com.revrobotics.CANSparkBase.ControlType;
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.CANSparkMaxLowLevel.PeriodicFrame;
 import com.revrobotics.MotorFeedbackSensor;

--- a/vendordeps/NavX.json
+++ b/vendordeps/NavX.json
@@ -1,7 +1,7 @@
 {
     "fileName": "NavX.json",
     "name": "NavX",
-    "version": "2024.0.1-beta-4",
+    "version": "2024.1.0",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-frc-java",
-            "version": "2024.0.1-beta-4"
+            "version": "2024.1.0"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-frc-cpp",
-            "version": "2024.0.1-beta-4",
+            "version": "2024.1.0",
             "headerClassifier": "headers",
             "sourcesClassifier": "sources",
             "sharedLibrary": false,

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.0.0-beta-6.2",
+    "version": "2024.1.1",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.0.0-beta-6.2"
+            "version": "2024.1.1"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.0.0-beta-6.2",
+            "version": "2024.1.1",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/Phoenix5.json
+++ b/vendordeps/Phoenix5.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix5.json",
     "name": "CTRE-Phoenix (v5)",
-    "version": "5.32.0-beta-4",
+    "version": "5.32.0-beta-5",
     "frcYear": 2024,
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
@@ -20,19 +20,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.32.0-beta-4"
+            "version": "5.32.0-beta-5"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.32.0-beta-4"
+            "version": "5.32.0-beta-5"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -60,7 +60,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -75,7 +75,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -90,7 +90,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -105,7 +105,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_Phoenix_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -120,7 +120,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "api-cpp-sim",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_PhoenixSim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -135,7 +135,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.32.0-beta-4",
+            "version": "5.32.0-beta-5",
             "libName": "CTRE_PhoenixCCISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/Phoenix6.json
+++ b/vendordeps/Phoenix6.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.0.0-beta-7",
+    "version": "24.0.0-beta-8",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.0.0-beta-7"
+            "version": "24.0.0-beta-8"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.0.0-beta-7",
+            "version": "24.0.0-beta-8",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.0.0",
+    "version": "2024.2.0",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.0.0"
+            "version": "2024.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
This updates _vendordep_s to use the currently available set of 2024 libraries.