### PR TITLE
Fix: Unit error in cosine compensator

### DIFF
--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -189,7 +189,7 @@ public class SwerveModule
       double steerMotorError = desiredState.angle.getDegrees() - getAbsolutePosition();
       /* If error is close to 0 rotations, we're already there, so apply full power */
       /* If the error is close to 0.25 rotations, then we're 90 degrees, so movement doesn't help us at all */
-      double cosineScalar = Math.cos(Units.rotationsToRadians(steerMotorError));
+      double cosineScalar = Math.cos(Units.degreesToRadians(steerMotorError));
       /* Make sure we don't invert our drive, even though we shouldn't ever target over 90 degrees anyway */
       if (cosineScalar < 0.0)
       {


### PR DESCRIPTION
`steerMotorError` is in degrees but then is referenced as rotations on line 192.