### PR TITLE
Fixed getDriveBaseRadiusMeters() as it incorrectly assumed there will always be 4 modules

### DIFF
--- a/src/main/java/swervelib/parser/SwerveDriveConfiguration.java
+++ b/src/main/java/swervelib/parser/SwerveDriveConfiguration.java
@@ -89,19 +89,14 @@ public class SwerveDriveConfiguration
    */
   public double getDriveBaseRadiusMeters()
   {
-    //Find Center of Robot by adding all module offsets together. Should be zero, but incase it isn't
-    Translation2d centerOfModules = moduleLocationsMeters[0].plus(moduleLocationsMeters[1])
-                                    .plus(moduleLocationsMeters[2]).plus(moduleLocationsMeters[3]);
+    Translation2d centerOfModules = moduleLocationsMeters[0];
 
-    //Find Largest Radius by checking the distance to the center point 
-    double largestRadius = centerOfModules.getDistance(moduleLocationsMeters[0]);     
+    //Calculate the Center by adding all module offsets together.
     for(int i=1; i<moduleLocationsMeters.length; i++){
-      if(largestRadius < centerOfModules.getDistance(moduleLocationsMeters[i])){
-        largestRadius = centerOfModules.getDistance(moduleLocationsMeters[i]);
-      }
-    }          
+      centerOfModules = centerOfModules.plus(moduleLocationsMeters[i]);
+    }  
     
     //Return Largest Radius
-    return largestRadius;
+    return centerOfModules.getDistance(moduleLocationsMeters[0]);
   }
 }


### PR DESCRIPTION
Previously assumed there would be 4 modules now allows for any amount greater than 2. Also revised the code as after it calculates the center it will just calculate one radius as it will be the same as every other module's radius.