### PR TITLE
Fixes the resetOdometry functions

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -646,7 +646,7 @@ public class SwerveDrive
   public void resetOdometry(Pose2d pose)
   {
     odometryLock.lock();
-    swerveDrivePoseEstimator.resetPosition(pose.getRotation(), getModulePositions(), pose);
+    swerveDrivePoseEstimator.resetPosition(getYaw(), getModulePositions(), pose);
     odometryLock.unlock();
     kinematics.toSwerveModuleStates(ChassisSpeeds.fromFieldRelativeSpeeds(0, 0, 0, pose.getRotation()));
   }


### PR DESCRIPTION
The call to  swerveDrivePoseEstimator.resetPosition should pass in the current gyro angle as the first argument.
Without this fix, it is impossible to start the robot in autonomous with a non-zero pose angle.

Thanks for YAGSL!