### PR TITLE
Fix heading correction for NavX IMU

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -454,7 +454,7 @@ public class SwerveDrive
       {
         if (!correctionEnabled)
         {
-          lastHeadingRadians = getOdometryHeading().getRadians();
+          lastHeadingRadians = getOdometryHeading().getRadians() + Math.PI;
           correctionEnabled = true;
         }
         velocity.omegaRadiansPerSecond =


### PR DESCRIPTION
This is the fix we had to make on our robot with a NavX IMU to get heading correction to work correctly. Prior to this fix, YAGSL would attempt to re-correct heading by rotating the robot by 180 degrees. I'm not sure if this fix is required for other IMUs - more investigation is required there.

Our working heading correction + full drivebase code here: https://github.com/jbko6/Crescendo2024