### PR TITLE
Fix typo in comments erroring out CI jobs

### DIFF
--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDrive.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDrive.java
@@ -30,7 +30,7 @@ public class AbsoluteDrive extends Command
   /**
    * Used to drive a swerve robot in full field-centric mode.  vX and vY supply translation inputs, where x is
    * torwards/away from alliance wall and y is left/right. headingHorzontal and headingVertical are the Cartesian
-   * coordinates from which the robot's angle will be derived— they will be converted to a polar angle, which the robot
+   * coordinates from which the robot's angle will be derived- they will be converted to a polar angle, which the robot
    * will rotate to.
    *
    * @param swerve            The swerve drivebase subsystem.

--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteFieldDrive.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteFieldDrive.java
@@ -28,7 +28,7 @@ public class AbsoluteFieldDrive extends Command
   /**
    * Used to drive a swerve robot in full field-centric mode.  vX and vY supply translation inputs, where x is
    * torwards/away from alliance wall and y is left/right. headingHorzontal and headingVertical are the Cartesian
-   * coordinates from which the robot's angle will be derived— they will be converted to a polar angle, which the robot
+   * coordinates from which the robot's angle will be derived- they will be converted to a polar angle, which the robot
    * will rotate to.
    *
    * @param swerve  The swerve drivebase subsystem.


### PR DESCRIPTION
Every time a Gradle build runs, it throws "soft errors" where unmappable characters are found and muddies up builds, as well as potentially failing CI.

Build error shown here: https://github.com/OakvilleDynamics/2024-Robot/actions/runs/7634385549/job/20798185423

This is because "—" ([em](https://www.thesaurus.com/e/grammar/em-dash/) [dash](https://en.wikipedia.org/wiki/Dash)) is not a standard US-ASCII character (or at least not according to Gradle), and should've been replaced by a "-" (hyphen).