### PR TITLE
Heading correction logic now reads in current heading

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -99,10 +99,6 @@ public class SwerveDrive
    */
   private       double                   HEADING_CORRECTION_DEADBAND                     = 0.01;
   /**
-   * Whether heading correction PID is currently active.
-   */
-  private       boolean                  correctionEnabled                               = false;
-  /**
    * Swerve IMU device for sensing the heading of the robot.
    */
   private       SwerveIMU                imu;
@@ -452,16 +448,12 @@ public class SwerveDrive
           && (Math.abs(velocity.vxMetersPerSecond) > HEADING_CORRECTION_DEADBAND
               || Math.abs(velocity.vyMetersPerSecond) > HEADING_CORRECTION_DEADBAND))
       {
-        if (!correctionEnabled)
-        {
-          lastHeadingRadians = getOdometryHeading().getRadians();
-          correctionEnabled = true;
-        }
         velocity.omegaRadiansPerSecond =
-            swerveController.headingCalculate(lastHeadingRadians, getOdometryHeading().getRadians());
-      } else
+            swerveController.headingCalculate(getOdometryHeading().getRadians(), lastHeadingRadians);
+      }
+      else
       {
-        correctionEnabled = false;
+        lastHeadingRadians = getOdometryHeading().getRadians();
       }
     }
 


### PR DESCRIPTION
The purpose of this commit is address the issue where heading correction is broken as indicated in the following link: https://github.com/BroncBotz3481/YAGSL/issues/44

The cause of this issue seems to be from the heading controller using the lastHeadingRadians as its measurement and the current heading as its target, causing the output to be inverted. This commit fixes this by swapping these values.