### PR TITLE
Increase joystick Deadband to 0.1 to prevent swerve module control issues

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -44,9 +44,9 @@ public final class Constants
   {
 
     // Joystick Deadband
-    public static final double LEFT_X_DEADBAND  = 0.01;
-    public static final double LEFT_Y_DEADBAND  = 0.01;
-    public static final double RIGHT_X_DEADBAND = 0.01;
+    public static final double LEFT_X_DEADBAND  = 0.1;
+    public static final double LEFT_Y_DEADBAND  = 0.1;
+    public static final double RIGHT_X_DEADBAND = 0.1;
     public static final double TURN_CONSTANT    = 6;
   }
 }


### PR DESCRIPTION
Changed the deadband values for LEFT_X_DEADBAND, LEFT_Y_DEADBAND, and RIGHT_X_DEADBAND from 0.01 to 0.1. This modification addresses the problem where swerve modules behave erratically and spin out of control with a lower deadband setting. The update is crucial for ensuring that issues related to modules spinning uncontrollably are attributed to motor invert problems and not confused with deadband settings. This change is particularly relevant for certain types/quality of controllers used.