### PR TITLE
Fixed the null pointer exception with CANCoderSwerve no canbus constructor

### DIFF
--- a/src/main/java/swervelib/encoders/CANCoderSwerve.java
+++ b/src/main/java/swervelib/encoders/CANCoderSwerve.java
@@ -45,7 +45,8 @@ public class CANCoderSwerve extends SwerveAbsoluteEncoder
    */
   public CANCoderSwerve(int id)
   {
-    encoder = new CANcoder(id);
+    // Empty string uses the default canbus for the system
+    this(id, "");
   }
 
   /**


### PR DESCRIPTION
The old no canbus CANCoderSwerve constructor didn't completely instantiate the alerts for the class, which could cause null pointer exceptions. This should fix those issues.