### PR TITLE
Update PID constants in SwerveSubsystem

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -103,7 +103,8 @@ public class SwerveSubsystem extends SubsystemBase
         this::getRobotVelocity, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
         this::setChassisSpeeds, // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds
         new HolonomicPathFollowerConfig( // HolonomicPathFollowerConfig, this should likely live in your Constants class
-                                         new PIDConstants(5.0, 0.0, 0.0),
+                                         new PIDConstants(0.01, 0.0, 0.0), //If you experience any
+                                         // oscillation or erratic behavior try lowering "kP"
                                          // Translation PID constants
                                          new PIDConstants(swerveDrive.swerveController.config.headingPIDF.p,
                                                           swerveDrive.swerveController.config.headingPIDF.i,


### PR DESCRIPTION
The P value of PID constants in the SwerveSubsystem has been reduced to 0.01 from 5.0. This change aims to prevent possible oscillation or erratic behavior by lowering the proportional gain ("kP").