### PR TITLE
Switch to Duty-Cycle, remove inversion, clean up various functions

### DIFF
--- a/src/main/java/swervelib/SwerveDriveTest.java
+++ b/src/main/java/swervelib/SwerveDriveTest.java
@@ -18,6 +18,7 @@ import edu.wpi.first.units.MutableMeasure;
 import edu.wpi.first.units.Velocity;
 import edu.wpi.first.units.Voltage;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.sysid.SysIdRoutineLog;
@@ -68,7 +69,7 @@ public class SwerveDriveTest
    * @param swerveDrive {@link SwerveDrive} to control.
    * @param percentage  DutyCycle percentage to send to angle motors.
    */
-  public static void powerAngleMotors(SwerveDrive swerveDrive, double percentage)
+  public static void powerAngleMotorsDutyCycle(SwerveDrive swerveDrive, double percentage)
   {
     for (SwerveModule swerveModule : swerveDrive.getModules())
     {
@@ -265,7 +266,7 @@ public class SwerveDriveTest
     log.motor("drive-" + module.configuration.name)
        .voltage(
            m_appliedVoltage.mut_replace(
-               module.getDriveMotor().getVoltage(), Volts))
+               module.getDriveMotor().getVoltage() / RobotController.getBatteryVoltage(), Volts))
        .linearPosition(m_distance.mut_replace(module.getPosition().distanceMeters, Meters))
        .linearVelocity(
            m_velocity.mut_replace(module.getDriveMotor().getVelocity(), MetersPerSecond));
@@ -286,7 +287,7 @@ public class SwerveDriveTest
     return new SysIdRoutine(config, new SysIdRoutine.Mechanism(
         (Measure<Voltage> voltage) -> {
           SwerveDriveTest.centerModules(swerveDrive);
-          SwerveDriveTest.powerDriveMotorsVoltage(swerveDrive, voltage.in(Volts));
+          SwerveDriveTest.powerDriveMotorsDutyCycle(swerveDrive, voltage.in(Volts) / RobotController.getBatteryVoltage());
         },
         log -> {
           for (SwerveModule module : swerveDrive.getModules())
@@ -313,7 +314,7 @@ public class SwerveDriveTest
     log.motor("angle-" + module.configuration.name)
        .voltage(
            m_appliedVoltage.mut_replace(
-               module.getAngleMotor().getVoltage(), Volts))
+               module.getAngleMotor().getVoltage() / RobotController.getBatteryVoltage(), Volts))
        .angularPosition(
            m_rotations.mut_replace(module.getAbsolutePosition(), Degrees))
        .angularVelocity(m_angVelocity.mut_replace(module.getAngleMotor().getVelocity(),
@@ -333,8 +334,8 @@ public class SwerveDriveTest
   {
     return new SysIdRoutine(config, new SysIdRoutine.Mechanism(
         (Measure<Voltage> voltage) -> {
-          SwerveDriveTest.powerAngleMotorsVoltage(swerveDrive, voltage.in(Volts));
-          SwerveDriveTest.powerDriveMotorsVoltage(swerveDrive, 0);
+          SwerveDriveTest.powerAngleMotorsDutyCycle(swerveDrive, voltage.in(Volts) / RobotController.getBatteryVoltage());
+          SwerveDriveTest.powerDriveMotorsDutyCycle(swerveDrive, 0);
         },
         log -> {
           for (SwerveModule module : swerveDrive.getModules())

--- a/src/main/java/swervelib/SwerveDriveTest.java
+++ b/src/main/java/swervelib/SwerveDriveTest.java
@@ -5,7 +5,6 @@ import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.DegreesPerSecond;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
@@ -233,7 +232,7 @@ public class SwerveDriveTest
   /**
    * Tracks the rotations of an angular motor
    */
-  private static final MutableMeasure<Angle>              m_rotations      = mutable(Rotations.of(0));
+  private static final MutableMeasure<Angle>              m_anglePosition  = mutable(Degrees.of(0));
   /**
    * Tracks the velocity of an angular motor
    */
@@ -314,7 +313,7 @@ public class SwerveDriveTest
            m_appliedVoltage.mut_replace(
                module.getAngleMotor().getVoltage() / RobotController.getBatteryVoltage(), Volts))
        .angularPosition(
-           m_rotations.mut_replace(module.getAbsolutePosition(), Degrees))
+           m_anglePosition.mut_replace(module.getAbsolutePosition(), Degrees))
        .angularVelocity(m_angVelocity.mut_replace(module.getAngleMotor().getVelocity(),
                                                   DegreesPerSecond));
   }
@@ -356,15 +355,12 @@ public class SwerveDriveTest
   public static Command generateSysIdCommand(SysIdRoutine sysIdRoutine, double delay, double quasiTimeout,
                                              double dynamicTimeout)
   {
-    return Commands.waitSeconds(quasiTimeout).deadlineWith(sysIdRoutine.quasistatic(SysIdRoutine.Direction.kForward))
+    return sysIdRoutine.quasistatic(SysIdRoutine.Direction.kForward).withTimeout(quasiTimeout)
                    .andThen(Commands.waitSeconds(delay))
-                   .andThen(Commands.waitSeconds(quasiTimeout)
-                                    .deadlineWith(sysIdRoutine.quasistatic(SysIdRoutine.Direction.kReverse)))
+                   .andThen(sysIdRoutine.quasistatic(SysIdRoutine.Direction.kReverse).withTimeout(quasiTimeout))
                    .andThen(Commands.waitSeconds(delay))
-                   .andThen(Commands.waitSeconds(dynamicTimeout)
-                                    .deadlineWith(sysIdRoutine.dynamic(SysIdRoutine.Direction.kForward)))
+                   .andThen(sysIdRoutine.dynamic(SysIdRoutine.Direction.kForward).withTimeout(dynamicTimeout))
                    .andThen(Commands.waitSeconds(delay))
-                   .andThen(Commands.waitSeconds(dynamicTimeout)
-                                    .deadlineWith(sysIdRoutine.dynamic(SysIdRoutine.Direction.kReverse)));
+                   .andThen(sysIdRoutine.dynamic(SysIdRoutine.Direction.kReverse).withTimeout(dynamicTimeout));
   }
 }

--- a/src/main/java/swervelib/SwerveDriveTest.java
+++ b/src/main/java/swervelib/SwerveDriveTest.java
@@ -10,7 +10,6 @@ import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.units.Angle;
 import edu.wpi.first.units.Distance;
 import edu.wpi.first.units.Measure;
@@ -87,8 +86,7 @@ public class SwerveDriveTest
   {
     for (SwerveModule swerveModule : swerveDrive.getModules())
     {
-      swerveModule.getDriveMotor().setVoltage(
-          volts * (swerveModule.getConfiguration().driveMotorInverted ? -1.0 : 1.0));
+      swerveModule.getDriveMotor().setVoltage(volts);
     }
   }
 


### PR DESCRIPTION
The switch to duty-cycle does give 'better' values that are in the right range without having to divide by 12.
One discovery is that the wheels don't go to the 0 position, but will set to 180 if they are closer to that. Starting the robot with the wheels set close to their origins fixes this. 
The clean up is just for better consistency of a few things like using DutyCycle in the Angle function and Degrees in the mutable. I also made use of withTImeout instead of deadline with in the command.