### PR TITLE
Update joystick deadband values

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -43,9 +43,9 @@ public final class Constants
   {
 
     // Joystick Deadband
-    public static final double LEFT_X_DEADBAND  = 0.01;
-    public static final double LEFT_Y_DEADBAND  = 0.01;
-    public static final double RIGHT_X_DEADBAND = 0.01;
+    public static final double LEFT_X_DEADBAND  = 0.1;
+    public static final double LEFT_Y_DEADBAND  = 0.1;
+    public static final double RIGHT_X_DEADBAND = 0.1;
     public static final double TURN_CONSTANT    = 6;
   }
 }


### PR DESCRIPTION
The constants for LEFT_X_DEADBAND, LEFT_Y_DEADBAND, and RIGHT_X_DEADBAND have been updated from 0.01 to 0.1. This adjustment may improve joystick responsiveness and arbitrary control movements from too low of a deadband.