### PR TITLE
Add zero gyro based on alliance

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -390,6 +390,28 @@ public class SwerveSubsystem extends SubsystemBase
     swerveDrive.zeroGyro();
   }
 
+  private boolean isRedAlliance() 
+  {
+    var alliance = DriverStation.getAlliance();
+    return alliance.isPresent() ? alliance.get() == DriverStation.Alliance.Red : false;
+  }
+
+  /**
+   * This will zero (calibrate) the robot to assume the current position is facing forward
+   * 
+   * If red alliance rotate the robot 180 after the drviebase zero command
+   */
+  public void zeroGyroWithAlliance() 
+  {
+    if (isRedAlliance()) {
+      zeroGyro();
+      //Set the pose 180 degrees
+      resetOdometry(new Pose2d(drivebase.getPose().getTranslation(), Rotation2d.fromDegrees(180)));
+    } else {
+       zeroGyro();      
+    }
+  }  
+
   /**
    * Sets the drive motors to brake/coast mode.
    *

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -406,7 +406,7 @@ public class SwerveSubsystem extends SubsystemBase
     if (isRedAlliance()) {
       zeroGyro();
       //Set the pose 180 degrees
-      resetOdometry(new Pose2d(drivebase.getPose().getTranslation(), Rotation2d.fromDegrees(180)));
+      resetOdometry(new Pose2d(getPose().getTranslation(), Rotation2d.fromDegrees(180)));
     } else {
        zeroGyro();      
     }


### PR DESCRIPTION
If red alliance is selected in Driver Station the robot will zero the gyro and rotate 180 to face "forward" based on being red alliance.