### PR TITLE
AbsoluteDriveAdv Command Rotation Fix

### DIFF
--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
@@ -103,7 +103,7 @@ public class AbsoluteDriveAdv extends Command
     // Prevent Movement After Auto
     if (resetHeading)
     {
-      if (headingX == 0 && headingY == 0 && Math.abs(headingAdjust.getAsDouble()) > 0)
+      if (headingX == 0 && headingY == 0 && Math.abs(headingAdjust.getAsDouble()) == 0)
       {
         // Get the curret Heading
         Rotation2d currentHeading = swerve.getHeading();


### PR DESCRIPTION
Fixes a logic issue that causes the AbsoluteDriveAdv Command to output zero angular velocity every other periodic call when using the manual heading adjustment