### PR TITLE
Move Maximum Speed to Constants.java

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -24,6 +24,7 @@ public final class Constants
   public static final double ROBOT_MASS = (148 - 20.3) * 0.453592; // 32lbs * kg per pound
   public static final Matter CHASSIS    = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
   public static final double LOOP_TIME  = 0.13; //s, 20ms + 110ms sprk max velocity lag
+  public static final double MAX_SPEED = Units.feetToMeters(14.5); // Maximum speed of the robot in meters per second, used to limit acceleration.
 
   public static final class AutonConstants
   {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -42,6 +42,15 @@ public class RobotContainer
     // Configure the trigger bindings
     configureBindings();
 
+
+
+    // Applies deadbands and inverts controls because joysticks
+    // are back-right positive while robot
+    // controls are front-left positive
+    // left stick controls translation
+    // right stick controls the rotational velocity 
+    // buttons are quick rotation positions to different ways to face
+    // WARNING: default buttons are on the same buttons as the ones defined in configureBindings
     AbsoluteDriveAdv closedAbsoluteDriveAdv = new AbsoluteDriveAdv(drivebase,
                                                                    () -> -MathUtil.applyDeadband(driverXbox.getLeftY(),
                                                                                                 OperatorConstants.LEFT_Y_DEADBAND),

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -26,6 +26,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
+import frc.robot.Constants;
 import frc.robot.Constants.AutonConstants;
 import java.io.File;
 import java.util.function.DoubleSupplier;
@@ -48,10 +49,6 @@ public class SwerveSubsystem extends SubsystemBase
    * Swerve drive object.
    */
   private final SwerveDrive swerveDrive;
-  /**
-   * Maximum speed of the robot in meters per second, used to limit acceleration.
-   */
-  public        double      maximumSpeed = Units.feetToMeters(14.5);
 
   /**
    * Initialize {@link SwerveDrive} with the directory provided.
@@ -78,7 +75,7 @@ public class SwerveSubsystem extends SubsystemBase
     SwerveDriveTelemetry.verbosity = TelemetryVerbosity.HIGH;
     try
     {
-      swerveDrive = new SwerveParser(directory).createSwerveDrive(maximumSpeed);
+      swerveDrive = new SwerveParser(directory).createSwerveDrive(Constants.MAX_SPEED);
       // Alternative method if you don't want to supply the conversion factor via JSON files.
       // swerveDrive = new SwerveParser(directory).createSwerveDrive(maximumSpeed, angleConversionFactor, driveConversionFactor);
     } catch (Exception e)
@@ -98,7 +95,7 @@ public class SwerveSubsystem extends SubsystemBase
    */
   public SwerveSubsystem(SwerveDriveConfiguration driveCfg, SwerveControllerConfiguration controllerCfg)
   {
-    swerveDrive = new SwerveDrive(driveCfg, controllerCfg, maximumSpeed);
+    swerveDrive = new SwerveDrive(driveCfg, controllerCfg, Constants.MAX_SPEED);
   }
 
   /**
@@ -516,7 +513,7 @@ public class SwerveSubsystem extends SubsystemBase
                                                         headingX,
                                                         headingY,
                                                         getHeading().getRadians(),
-                                                        maximumSpeed);
+                                                        Constants.MAX_SPEED);
   }
 
   /**
@@ -536,7 +533,7 @@ public class SwerveSubsystem extends SubsystemBase
                                                         yInput,
                                                         angle.getRadians(),
                                                         getHeading().getRadians(),
-                                                        maximumSpeed);
+                                                        Constants.MAX_SPEED);
   }
 
   /**

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -102,6 +102,10 @@ public class SwerveDrive
    */
   public        boolean                  headingCorrection                               = false;
   /**
+   * Amount of seconds the duration of the timestep the speeds should be applied for.
+   */
+  public        double                   discretizationdtSeconds                         = 0.02;
+  /**
    * Deadband for speeds in heading correction.
    */
   private       double                   HEADING_CORRECTION_DEADBAND                     = 0.01;
@@ -464,7 +468,7 @@ public class SwerveDrive
     // https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964/5
     if (chassisVelocityCorrection)
     {
-      velocity = ChassisSpeeds.discretize(velocity, 0.02);
+      velocity = ChassisSpeeds.discretize(velocity, discretizationdtSeconds);
     }
 
     // Heading Angular Velocity Deadband, might make a configuration option later.
@@ -501,62 +505,6 @@ public class SwerveDrive
 
     setRawModuleStates(swerveModuleStates, isOpenLoop);
   }
-
-    /**
-   * The primary method for controlling the drivebase. Takes a {@link ChassisSpeeds}, and calculates and commands module
-   * states accordingly. Can use either open-loop or closed-loop velocity control for the wheel velocities. Applies
-   * heading correction if enabled and necessary.
-   *
-   * @param velocity               The chassis speeds to set the robot to achieve.
-   * @param isOpenLoop             Whether to use closed-loop velocity control. Set to true to disable closed-loop.
-   * @param centerOfRotationMeters The center of rotation in meters, 0 is the center of the robot.
-   * @param dtSeconds              The duration of the timestep the speeds should be applied for.  
-   */
-  public void drive(ChassisSpeeds velocity, boolean isOpenLoop, Translation2d centerOfRotationMeters, double dtSeconds)
-  {
-
-    // Thank you to Jared Russell FRC254 for Open Loop Compensation Code
-    // https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964/5
-    if (chassisVelocityCorrection)
-    {
-      velocity = ChassisSpeeds.discretize(velocity, dtSeconds);
-    }
-
-    // Heading Angular Velocity Deadband, might make a configuration option later.
-    // Originally made by Team 1466 Webb Robotics.
-    // Modified by Team 7525 Pioneers and BoiledBurntBagel of 6036
-    if (headingCorrection)
-    {
-      if (Math.abs(velocity.omegaRadiansPerSecond) < HEADING_CORRECTION_DEADBAND
-          && (Math.abs(velocity.vxMetersPerSecond) > HEADING_CORRECTION_DEADBAND
-              || Math.abs(velocity.vyMetersPerSecond) > HEADING_CORRECTION_DEADBAND))
-      {
-        velocity.omegaRadiansPerSecond =
-            swerveController.headingCalculate(getOdometryHeading().getRadians(), lastHeadingRadians);
-      } else
-      {
-        lastHeadingRadians = getOdometryHeading().getRadians();
-      }
-    }
-
-    // Display commanded speed for testing
-    if (SwerveDriveTelemetry.verbosity == TelemetryVerbosity.INFO)
-    {
-      SmartDashboard.putString("RobotVelocity", velocity.toString());
-    }
-    if (SwerveDriveTelemetry.verbosity.ordinal() >= TelemetryVerbosity.LOW.ordinal())
-    {
-      SwerveDriveTelemetry.desiredChassisSpeeds[1] = velocity.vyMetersPerSecond;
-      SwerveDriveTelemetry.desiredChassisSpeeds[0] = velocity.vxMetersPerSecond;
-      SwerveDriveTelemetry.desiredChassisSpeeds[2] = Math.toDegrees(velocity.omegaRadiansPerSecond);
-    }
-
-    // Calculate required module states via kinematics
-    SwerveModuleState[] swerveModuleStates = kinematics.toSwerveModuleStates(velocity, centerOfRotationMeters);
-
-    setRawModuleStates(swerveModuleStates, isOpenLoop);
-  }
-
 
   /**
    * Set the maximum speeds for desaturation.
@@ -1209,6 +1157,11 @@ public class SwerveDrive
     {
       module.configuration.useCosineCompensator = enabled;
     }
+  }
+
+  public void setChassisDiscretization(boolean enable, double dtSeconds){
+    chassisVelocityCorrection = enable;
+    discretizationdtSeconds = dtSeconds;
   }
 
 }

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -347,6 +347,19 @@ public class SwerveDrive
   }
 
   /**
+   * Tertiary method of controlling the drive base given velocity in both field oriented and robot oriented at the same time. 
+   * The inputs are added together so this is not intneded to be used to give the driver both methods of control.
+   * 
+   * @param fieldOrientedVelocity The field oriented velocties to use
+   * @param robotOrientedVelocity The robot oriented velocties to use
+   */
+  public void driveFieldOrientedandRobotOriented(ChassisSpeeds fieldOrientedVelocity, ChassisSpeeds robotOrientedVelocity)
+  {
+    ChassisSpeeds TotalVelocties = ChassisSpeeds.fromFieldRelativeSpeeds(fieldOrientedVelocity, getOdometryHeading()).plus(robotOrientedVelocity);
+    drive(TotalVelocties);
+  }
+
+  /**
    * Secondary method of controlling the drive base given velocity and adjusting it for field oriented use.
    *
    * @param velocity Velocity of the robot desired.

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -1125,11 +1125,11 @@ public class SwerveDrive
    * Pushes the Absolute Encoder offsets to the Encoder or Motor Controller, depending on type. Also removes the
    * internal offsets to prevent double offsetting.
    */
-  public void pushOffsetsToControllers()
+  public void pushOffsetsToEncoders()
   {
     for (SwerveModule module : swerveModules)
     {
-      module.pushOffsetsToControllers();
+      module.pushOffsetsToEncoders();
     }
   }
 

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -104,7 +104,7 @@ public class SwerveDrive
   /**
    * Amount of seconds the duration of the timestep the speeds should be applied for.
    */
-  public        double                   discretizationdtSeconds                         = 0.02;
+  private        double                   discretizationdtSeconds                         = 0.02;
   /**
    * Deadband for speeds in heading correction.
    */
@@ -1159,6 +1159,12 @@ public class SwerveDrive
     }
   }
 
+  /**
+   * Sets the Chassis discretization seconds as well as enableing/disabling the Chassis velocity correction
+   * 
+   * @param enable
+   * @param dtSeconds
+   */
   public void setChassisDiscretization(boolean enable, double dtSeconds){
     chassisVelocityCorrection = enable;
     discretizationdtSeconds = dtSeconds;

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -252,7 +252,7 @@ public class SwerveModule
     this.antiJitterEnabled = antiJitter;
     if (antiJitter)
     {
-      pushOffsetsToControllers();
+      pushOffsetsToEncoders();
     } else
     {
       restoreInternalOffset();
@@ -580,7 +580,7 @@ public class SwerveModule
   /**
    * Push absolute encoder offset in the memory of the encoder or controller. Also removes the internal angle offset.
    */
-  public void pushOffsetsToControllers()
+  public void pushOffsetsToEncoders()
   {
     if (absoluteEncoder != null && angleOffset == configuration.angleOffset)
     {


### PR DESCRIPTION
Moved Maximum Speed to constants.java and added a comment to AbsoluteFieldDriveAdv. 

I would also love to move this block of code out of swerve subsystem as I imagine most teams find it a bit confusing as it is already in the JSON files, but I understand why it is there. 

`// Angle conversion factor is 360 / (GEAR RATIO * ENCODER RESOLUTION)
    //  In this case the gear ratio is 12.8 motor revolutions per wheel rotation.
    //  The encoder resolution per motor revolution is 1 per motor revolution.
    double angleConversionFactor = SwerveMath.calculateDegreesPerSteeringRotation(12.8);
    // Motor conversion factor is (PI * WHEEL DIAMETER IN METERS) / (GEAR RATIO * ENCODER RESOLUTION).
    //  In this case the wheel diameter is 4 inches, which must be converted to meters to get meters/second.
    //  The gear ratio is 6.75 motor revolutions per wheel rotation.
    //  The encoder resolution per motor revolution is 1 per motor revolution.
    double driveConversionFactor = SwerveMath.calculateMetersPerRotation(Units.inchesToMeters(4), 6.75);
    System.out.println("\"conversionFactor\": {");
    System.out.println("\t\"angle\": " + angleConversionFactor + ",");
    System.out.println("\t\"drive\": " + driveConversionFactor);
    System.out.println("}");`