### PR TITLE
Add ability to get the rotation rate from the IMU

### DIFF
--- a/src/main/java/swervelib/imu/ADIS16448Swerve.java
+++ b/src/main/java/swervelib/imu/ADIS16448Swerve.java
@@ -111,6 +111,14 @@ public class ADIS16448Swerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(imu.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/ADIS16470Swerve.java
+++ b/src/main/java/swervelib/imu/ADIS16470Swerve.java
@@ -111,6 +111,14 @@ public class ADIS16470Swerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(imu.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/ADXRS450Swerve.java
+++ b/src/main/java/swervelib/imu/ADXRS450Swerve.java
@@ -109,6 +109,14 @@ public class ADXRS450Swerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(imu.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/AnalogGyroSwerve.java
+++ b/src/main/java/swervelib/imu/AnalogGyroSwerve.java
@@ -116,6 +116,14 @@ public class AnalogGyroSwerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(gyro.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/NavXSwerve.java
+++ b/src/main/java/swervelib/imu/NavXSwerve.java
@@ -178,6 +178,14 @@ public class NavXSwerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(gyro.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/Pigeon2Swerve.java
+++ b/src/main/java/swervelib/imu/Pigeon2Swerve.java
@@ -139,6 +139,14 @@ public class Pigeon2Swerve extends SwerveIMU
   }
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(imu.getRate());
+  }
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.

--- a/src/main/java/swervelib/imu/PigeonSwerve.java
+++ b/src/main/java/swervelib/imu/PigeonSwerve.java
@@ -115,6 +115,14 @@ public class PigeonSwerve extends SwerveIMU
     return Optional.of(new Translation3d(initial[0], initial[1], initial[2]).times(9.81 / 16384.0));
   }
 
+   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public Optional<Double> getRate() {
+    return Optional.of(imu.getRate());
+  }
+
   /**
    * Get the instantiated IMU object.
    *

--- a/src/main/java/swervelib/imu/SwerveIMU.java
+++ b/src/main/java/swervelib/imu/SwerveIMU.java
@@ -57,6 +57,12 @@ public abstract class SwerveIMU
   public abstract Optional<Translation3d> getAccel();
 
   /**
+   * Fetch the rotation rate from the IMU in degrees per second. If rotation rate isn't supported returns empty.
+   * @return {@link Double} of the rotation rate as an {@link Optional}.
+   */
+  public abstract Optional<Double> getRate();
+
+  /**
    * Get the instantiated IMU object.
    *
    * @return IMU object.


### PR DESCRIPTION
Adds a getRate function that returns an Optional<Double> of the rotation rate in degrees per sec. This was supported by all the IMU types, so the Optional may be overkill. I'm mainly asking for this because our code had a need for it and I wanted to only have the gyro defined in one place. This also makes the YAGSL interface to the IMUs more complete. Let me know if there's any changes I should make.