### PR TITLE
Updating Vendordeps and renaming CanandCoders to CanandMags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -339,8 +339,8 @@
                 <option value="sparkmax_analog">Attached (to SparkMAX Analog Pin)</option>
                 <option value="sparkmax_analog">Attached (to SparkMAX Analog Pin)</option>
                 <option value="cancoder">CANCoder</option>
-                <option value="canandcoder">CANandCoder (attached to SparkMAX)</option>
-                <option value="canandcoder_can">CANandCoder (CAN)</option>
+                <option value="canandmag">CANandMag (attached to SparkMAX)</option>
+                <option value="canandmag_can">CANandMag (CAN)</option>
                 <option value="ma3">MA3</option>
                 <option value="ctre_mag">CTRE Mag</option>
                 <option value="rev_hex">REV Hex</option>
@@ -551,8 +551,8 @@
                 <option value="attached">Attached (to SparkMAX)</option>
                 <option value="sparkmax_analog">Attached (to SparkMAX Analog Pin)</option>
                 <option value="cancoder">CANCoder</option>
-                <option value="canandcoder">CANandCoder (attached to SparkMAX)</option>
-                <option value="canandcoder_can">CANandCoder (CAN)</option>
+                <option value="canandmag">CANandMag (attached to SparkMAX)</option>
+                <option value="canandmag_can">CANandMag (CAN)</option>
                 <option value="ma3">MA3</option>
                 <option value="ctre_mag">CTRE Mag</option>
                 <option value="rev_hex">REV Hex</option>
@@ -761,8 +761,8 @@
                 <option value="attached">Attached (to SparkMAX)</option>
                 <option value="sparkmax_analog">Attached (to SparkMAX Analog Pin)</option>
                 <option value="cancoder">CANCoder</option>
-                <option value="canandcoder">CANandCoder (attached to SparkMAX)</option>
-                <option value="canandcoder_can">CANandCoder (CAN)</option>
+                <option value="canandmag">CANandMag (attached to SparkMAX)</option>
+                <option value="canandmag_can">CANandMag (CAN)</option>
                 <option value="ma3">MA3</option>
                 <option value="ctre_mag">CTRE Mag</option>
                 <option value="rev_hex">REV Hex</option>
@@ -975,8 +975,8 @@
                 <option value="attached">Attached (to SparkMAX)</option>
                 <option value="sparkmax_analog">Attached (to SparkMAX Analog Pin)</option>
                 <option value="cancoder">CANCoder</option>
-                <option value="canandcoder">CANandCoder (attached to SparkMAX)</option>
-                <option value="canandcoder_can">CANandCoder (CAN)</option>
+                <option value="canandmag">CANandMag (attached to SparkMAX)</option>
+                <option value="canandmag_can">CANandMag (CAN)</option>
                 <option value="ma3">MA3</option>
                 <option value="ctre_mag">CTRE Mag</option>
                 <option value="rev_hex">REV Hex</option>

--- a/src/main/java/swervelib/encoders/CanAndMagSwerve.java
+++ b/src/main/java/swervelib/encoders/CanAndMagSwerve.java
@@ -1,26 +1,26 @@
 package swervelib.encoders;
 
-import com.reduxrobotics.sensors.canandcoder.Canandcoder;
+import com.reduxrobotics.sensors.canandmag.Canandmag;
 
 /**
- * HELIUM {@link Canandcoder} from ReduxRobotics absolute encoder, attached through the CAN bus.
+ * HELIUM {@link Canandmag} from ReduxRobotics absolute encoder, attached through the CAN bus.
  */
-public class CanAndCoderSwerve extends SwerveAbsoluteEncoder
+public class CanAndMagSwerve extends SwerveAbsoluteEncoder
 {
 
   /**
-   * The {@link Canandcoder} representing the CANandCoder on the CAN bus.
+   * The {@link Canandmag} representing the CANandMag on the CAN bus.
    */
-  public Canandcoder encoder;
+  public Canandmag encoder;
 
   /**
-   * Create the {@link Canandcoder}
+   * Create the {@link Canandmag}
    *
-   * @param canid The CAN ID whenever the CANandCoder is operating on the CANBus.
+   * @param canid The CAN ID whenever the CANandMag is operating on the CANBus.
    */
-  public CanAndCoderSwerve(int canid)
+  public CanAndMagSwerve(int canid)
   {
-    encoder = new Canandcoder(canid);
+    encoder = new Canandmag(canid);
   }
 
   /**
@@ -44,14 +44,14 @@ public class CanAndCoderSwerve extends SwerveAbsoluteEncoder
   }
 
   /**
-   * Configure the Canandcoder to read from [0, 360) per second.
+   * Configure the Canandmag to read from [0, 360) per second.
    *
    * @param inverted Whether the encoder is inverted.
    */
   @Override
   public void configure(boolean inverted)
   {
-    encoder.setSettings(new Canandcoder.Settings().setInvertDirection(inverted));
+    encoder.setSettings(new Canandmag.Settings().setInvertDirection(inverted));
   }
 
   /**
@@ -77,7 +77,7 @@ public class CanAndCoderSwerve extends SwerveAbsoluteEncoder
   }
 
   /**
-   * Cannot set the offset of the Canandcoder.
+   * Cannot set the offset of the Canandmag.
    *
    * @param offset the offset the Absolute Encoder uses as the zero point.
    * @return true if setting the zero point succeeded, false otherwise
@@ -85,7 +85,7 @@ public class CanAndCoderSwerve extends SwerveAbsoluteEncoder
   @Override
   public boolean setAbsoluteEncoderOffset(double offset)
   {
-    return encoder.setSettings(new Canandcoder.Settings().setZeroOffset(offset));
+    return encoder.setSettings(new Canandmag.Settings().setZeroOffset(offset));
   }
 
   /**

--- a/src/main/java/swervelib/parser/json/DeviceJson.java
+++ b/src/main/java/swervelib/parser/json/DeviceJson.java
@@ -11,7 +11,7 @@ import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.SerialPort.Port;
 import swervelib.encoders.AnalogAbsoluteEncoderSwerve;
 import swervelib.encoders.CANCoderSwerve;
-import swervelib.encoders.CanAndCoderSwerve;
+import swervelib.encoders.CanAndMagSwerve;
 import swervelib.encoders.PWMDutyCycleEncoderSwerve;
 import swervelib.encoders.SparkMaxAnalogEncoderSwerve;
 import swervelib.encoders.SparkMaxEncoderSwerve;
@@ -72,10 +72,10 @@ public class DeviceJson
         return new SparkMaxEncoderSwerve(motor, 1);
       case "sparkmax_analog":
         return new SparkMaxAnalogEncoderSwerve(motor);
-      case "canandcoder":
+      case "canandmag":
         return new SparkMaxEncoderSwerve(motor, 360);
-      case "canandcoder_can":
-        return new CanAndCoderSwerve(id);
+      case "canandmag_can":
+        return new CanAndMagSwerve(id);
       case "ctre_mag":
       case "rev_hex":
       case "throughbore":

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.2.4",
+    "version": "2024.2.8",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.2.4"
+            "version": "2024.2.8"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.2.4",
+            "version": "2024.2.8",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/Phoenix6.json
+++ b/vendordeps/Phoenix6.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix6.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "24.2.0",
+    "version": "24.3.0",
     "frcYear": 2024,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "24.2.0"
+            "version": "24.3.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -39,7 +39,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -52,7 +52,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -65,7 +65,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -78,7 +78,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -91,7 +91,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -104,7 +104,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -117,7 +117,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -130,7 +130,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -143,7 +143,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -158,7 +158,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -173,7 +173,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -188,7 +188,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -203,7 +203,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -218,7 +218,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -233,7 +233,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -248,7 +248,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -263,7 +263,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -278,7 +278,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -293,7 +293,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -308,7 +308,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -323,7 +323,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "24.2.0",
+            "version": "24.3.0",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.2.3",
+    "version": "2024.2.4",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.2.3"
+            "version": "2024.2.4"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.3",
+            "version": "2024.2.4",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.2.3",
+            "version": "2024.2.4",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.2.3",
+            "version": "2024.2.4",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
The first commit just updates a few vendordeps, nothing too important.
The second commit updates references to the ReduxLib API as CanandCoders have been renamed to CanandMags.  It also updates the swervelib documentation.