### PR TITLE
Add Standard Deviations for YAGSL SwerveDrive Pose Estimator

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -5,7 +5,12 @@
 package frc.robot;
 
 import com.pathplanner.lib.util.PIDConstants;
+
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.Matrix;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
 import swervelib.math.Matter;
 
@@ -48,5 +53,14 @@ public final class Constants
     public static final double LEFT_Y_DEADBAND  = 0.1;
     public static final double RIGHT_X_DEADBAND = 0.1;
     public static final double TURN_CONSTANT    = 6;
+  }
+
+  public static class Vision
+  {
+    // The standard deviations of  vision estimated poses, which affect correction rate
+    // (Fake values. Experiment and determine estimation noise on an actual robot.)
+    // https://www.chiefdelphi.com/t/photonvision-finding-standard-deviations-for-swervedriveposeestimator/467802/2
+    public static final Matrix<N3, N1> kSingleTagStdDevs = VecBuilder.fill(4, 4, 8);
+    public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bad615cc-aa22-46a2-9a66-a34daea56586)
Implemented the method from PhotonVision's code example that returns the stdDevs for a given camera, to be used with the SwerveDrivePoseEstimator instead of only filtering the poses. This function changes the standard deviations based on the distance and number of tags seen. (e.g. trust the pose values more if the robot sees multiple tags, don't trust the pose values if the robot is far away and only sees 1 tag). However, I had to change some other methods to integrate this. Let me know if I broke anything!

