### PR TITLE
Update the vision simulation on Vision#updatePoseEstimation

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -209,10 +209,13 @@ public class Vision
    */
   public void updatePoseEstimation(SwerveDrive swerveDrive)
   {
-    for (EstimatedRobotPose i : getEstimatedGlobalPose())
-    {
-      swerveDrive.addVisionMeasurement(i.estimatedPose.toPose2d(), i.timestampSeconds);
-    }
+    ArrayList<EstimatedRobotPose> estimatedRobotPoses = getEstimatedGlobalPose();
+    if(Robot.isReal()) {
+      for (EstimatedRobotPose i : estimatedRobotPoses)
+      {
+        swerveDrive.addVisionMeasurement(i.estimatedPose.toPose2d(), i.timestampSeconds);
+      }
+    } else visionSim.update(swerveDrive.getPose());
   }
 
   /**


### PR DESCRIPTION
This fixes the PhotonVision simulation not updating and stops issues where the pose estimations move the robot pose in the simulation