### PR TITLE
Angular velocity correction

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -96,6 +96,9 @@ public class SwerveSubsystem extends SubsystemBase
     }
     swerveDrive.setHeadingCorrection(false); // Heading correction should only be used while controlling the robot via angle.
     swerveDrive.setCosineCompensator(false);//!SwerveDriveTelemetry.isSimulation); // Disables cosine compensation for simulations since it causes discrepancies not seen in real life.
+    swerveDrive.setAngularVelocityCompensation(true, 0.1); //Correct for skew that gets worse as angular velocity increases. Start with a coefficient of 0.1.
+    //Setting to true by default for testing, below is how I would push it
+    //swerveDrive.setAngularVelocityCompensation(false, 0); //Correct for skew that gets worse as angular velocity increases. Start with a coefficient of 0.1.
     if (visionDriveTest)
     {
       setupPhotonVision();

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import swervelib.encoders.CANCoderSwerve;
+import swervelib.imu.IMUVelocity;
 import swervelib.imu.Pigeon2Swerve;
 import swervelib.imu.SwerveIMU;
 import swervelib.math.SwerveMath;
@@ -98,6 +99,15 @@ public class SwerveDrive
    */
   public        boolean                  chassisVelocityCorrection                       = true;
   /**
+   * Correct for skew that scales with angular velocity in {@link SwerveDrive#drive(Translation2d, double, boolean, boolean)}
+   * TODO: Still working on the explanation, I will have it ready soon (hopefully)
+   */
+  public        boolean                  angularVelocityCorrection                      = false;
+  /**
+   * Angular Velocity Correction Coefficent (expected values between -0.15 and 0.15).
+   */
+  public        double                   angularVelocityCoefficient                     = 0;
+  /**
    * Whether to correct heading when driving translationally. Set to true to enable.
    */
   public        boolean                  headingCorrection                               = false;
@@ -113,6 +123,11 @@ public class SwerveDrive
    * Swerve IMU device for sensing the heading of the robot.
    */
   private       SwerveIMU                imu;
+  /**
+   * Class that calculates robot's yaw velocity using IMU measurements. Used for angularVelocityCorrection in 
+   * {@link SwerveDrive#drive(Translation2d, double, boolean, boolean)}.
+   */
+  private       IMUVelocity             imuVelocity;
   /**
    * Simulation of the swerve drive.
    */
@@ -479,6 +494,22 @@ public class SwerveDrive
   public void drive(ChassisSpeeds velocity, boolean isOpenLoop, Translation2d centerOfRotationMeters)
   {
 
+    // Explanation coming soon
+    if(angularVelocityCorrection)
+    {
+      // TODO: I still haven't done the math on the 1 million multipler, I will do that asap but I am pushing it for now
+      // This multipler should be built into the imuVelocity.getVelocity() function and is almost certainly dependand on the timestep used
+      var angularVelocity = new Rotation2d(imuVelocity.getVelocity() * 1000000 * angularVelocityCoefficient);
+      if(angularVelocity.getRadians() != 0.0){
+        velocity = ChassisSpeeds.fromRobotRelativeSpeeds(
+                      velocity.vxMetersPerSecond,
+                      velocity.vyMetersPerSecond,
+                      velocity.omegaRadiansPerSecond,
+                      getOdometryHeading());
+        velocity = ChassisSpeeds.fromFieldRelativeSpeeds(velocity, getOdometryHeading().plus(angularVelocity));
+      }
+    }
+
     // Thank you to Jared Russell FRC254 for Open Loop Compensation Code
     // https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964/5
     if (chassisVelocityCorrection)
@@ -610,6 +641,46 @@ public class SwerveDrive
    */
   public void setChassisSpeeds(ChassisSpeeds chassisSpeeds)
   {
+    SwerveDriveTelemetry.desiredChassisSpeeds[1] = chassisSpeeds.vyMetersPerSecond;
+    SwerveDriveTelemetry.desiredChassisSpeeds[0] = chassisSpeeds.vxMetersPerSecond;
+    SwerveDriveTelemetry.desiredChassisSpeeds[2] = Math.toDegrees(chassisSpeeds.omegaRadiansPerSecond);
+
+    setRawModuleStates(kinematics.toSwerveModuleStates(chassisSpeeds), false);
+  }
+    /**
+   * Set chassis speeds with closed-loop velocity control, using the optimizations present 
+   * in {@link SwerveDrive#drive(Translation2d, double, boolean, boolean)}. This may improve
+   * performance during autonomous, if the optimizations make you drive straight in teleop then 
+   * they should help in autonomous, think of this as a feedforward that reduces the correction needed
+   * from PID due to skew.
+   *
+   * @param chassisSpeeds Chassis speeds to set.
+   */
+  public void setChassisSpeedsWithDriveOptimizations(ChassisSpeeds chassisSpeeds)
+  {
+    // Explanation coming soon
+    if(angularVelocityCorrection)
+    {
+      // TODO: I still haven't done the math on the 1 million multipler, I will do that asap but I am pushing it for now
+      // This multipler should be built into the imuVelocity.getVelocity() function and is almost certainly dependand on the timestep used
+      var angularVelocity = new Rotation2d(imuVelocity.getVelocity() * 1000000 * angularVelocityCoefficient);
+      if(angularVelocity.getRadians() != 0.0){
+        chassisSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(
+                      chassisSpeeds.vxMetersPerSecond,
+                      chassisSpeeds.vyMetersPerSecond,
+                      chassisSpeeds.omegaRadiansPerSecond,
+                      getOdometryHeading());
+        chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(chassisSpeeds, getOdometryHeading().plus(angularVelocity));
+      }
+    }
+
+    // Thank you to Jared Russell FRC254 for Open Loop Compensation Code
+    // https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964/5
+    if (chassisVelocityCorrection)
+    {
+      chassisSpeeds = ChassisSpeeds.discretize(chassisSpeeds, discretizationdtSeconds);
+    }
+
     SwerveDriveTelemetry.desiredChassisSpeeds[1] = chassisSpeeds.vyMetersPerSecond;
     SwerveDriveTelemetry.desiredChassisSpeeds[0] = chassisSpeeds.vxMetersPerSecond;
     SwerveDriveTelemetry.desiredChassisSpeeds[2] = Math.toDegrees(chassisSpeeds.omegaRadiansPerSecond);
@@ -1215,6 +1286,29 @@ public class SwerveDrive
   {
     chassisVelocityCorrection = enable;
     discretizationdtSeconds = dtSeconds;
+  }
+
+  /**
+   * Enables angular velocity correction and sets the angular velocity coefficient
+   *
+   * @param enable               Enables angular velocity correction.
+   * @param angularVelocityCoeff The angular velocity coefficient. Expected values between -0.15 to 0.15, although higher values may be needed.
+   *                             Start with a value of 0.1.
+   *                             When enabling for the first time if the skew is significantly worse try inverting the value.
+   *                             Tune by moving in a straight line while rotating. Change the value until you are visually happy with the skew.
+   *                             Ensure your tune works with different translational and rotational magnitudes.
+   */
+  public void setAngularVelocityCompensation(boolean enable, double angularVelocityCoeff)
+  {
+    /** TODO: How should it behave in the case of simulation? Skew doesn't really exist in simulation, 
+     * discretize could also be removed in simulation as it creates skew in the simulation, 
+     * the skew it corrects is only present on a real bot.
+     * This makes the robot continously rotate due to a lack of friction.
+     * My vote is to disable both discretize and angular velocity correction.
+     */
+    imuVelocity = new IMUVelocity(imu);
+    angularVelocityCorrection = true;
+    angularVelocityCoefficient = angularVelocityCoeff;
   }
 
 }

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -498,7 +498,7 @@ public class SwerveDrive
     if(angularVelocityCorrection)
     {
       // TODO: I still haven't done the math on the 1 million multipler, I will do that asap but I am pushing it for now
-      // This multipler should be built into the imuVelocity.getVelocity() function and is almost certainly dependand on the timestep used
+      // This multipler should be built into the imuVelocity.getVelocity() method and is almost certainly dependant on the timestep used
       var angularVelocity = new Rotation2d(imuVelocity.getVelocity() * 1000000 * angularVelocityCoefficient);
       if(angularVelocity.getRadians() != 0.0){
         velocity = ChassisSpeeds.fromRobotRelativeSpeeds(
@@ -650,9 +650,9 @@ public class SwerveDrive
     /**
    * Set chassis speeds with closed-loop velocity control, using the optimizations present 
    * in {@link SwerveDrive#drive(Translation2d, double, boolean, boolean)}. This may improve
-   * performance during autonomous, if the optimizations make you drive straight in teleop then 
-   * they should help in autonomous, think of this as a feedforward that reduces the correction needed
-   * from PID due to skew.
+   * performance during autonomous, if the optimizations reduce your bot's skew in teleop then 
+   * they should help in autonomous, think of this as a feedforward that reduces the correction 
+   * needed from PID due to skew.
    *
    * @param chassisSpeeds Chassis speeds to set.
    */
@@ -662,7 +662,7 @@ public class SwerveDrive
     if(angularVelocityCorrection)
     {
       // TODO: I still haven't done the math on the 1 million multipler, I will do that asap but I am pushing it for now
-      // This multipler should be built into the imuVelocity.getVelocity() function and is almost certainly dependand on the timestep used
+      // This multipler should be built into the imuVelocity.getVelocity() function and is almost certainly dependant on the timestep used
       var angularVelocity = new Rotation2d(imuVelocity.getVelocity() * 1000000 * angularVelocityCoefficient);
       if(angularVelocity.getRadians() != 0.0){
         chassisSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(

--- a/src/main/java/swervelib/imu/IMUVelocity.java
+++ b/src/main/java/swervelib/imu/IMUVelocity.java
@@ -1,0 +1,99 @@
+package swervelib.imu;
+
+import edu.wpi.first.math.filter.LinearFilter;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.Notifier;
+import edu.wpi.first.wpilibj.RobotController;
+
+public class IMUVelocity {
+  /**
+   * Swerve IMU.
+   */
+  private final SwerveIMU gyro;
+  /**
+   * Linear filter used to calculate velocity.
+   */
+  private final LinearFilter velocityFilter;
+  /**
+   * WPILib {@link Notifier} to keep IMU velocity up to date.
+   */
+  private final Notifier  notifier;
+
+  /**
+   * Prevents calculation when no previous measurement exists.
+   */
+  private boolean firstCycle = true;
+  /**
+   * Tracks the previous loop's recorded time.
+   */
+  private double timestamp = 0.0;
+  /**
+   * Tracks the previous loop's position as a Rotation2d. 
+   */
+  private Rotation2d position = new Rotation2d();
+  /**
+   * The calculated velocity of the robot based on averaged IMU measurements.
+   */
+  private double velocity = 0.0;
+
+  /**
+   * Constructor for the IMU Velocity. Defaults to an IMU polling rate of 50hz 
+   * and 5 taps for moving average linear filter.
+   *
+   * @param gyro The SwerveIMU gyro.
+   */
+  public IMUVelocity(SwerveIMU gyro)
+  {
+    /* TODO: For now I am going to assume that gyros operate at 60hz or more by default  */
+    /* NAVX2.0 defaults to 60hz, Pigeon2 is 100hz  */
+    this(gyro, 1.0/60.0, 5);
+  }
+
+  /**
+   * Constructor for the IMU Velocity.
+   *
+   * @param gyro The SwerveIMU gyro.
+   * @param periodSeconds The rate to collect measurements from the gyro, in the form (1/number of samples per second),
+   * make sure this does not exceed the update rate of your IMU.
+   * @param averagingTaps The number of samples to used for the moving average linear filter. Higher values will not
+   * allow the system to update to changes in velocity, lower values may create a less smooth signal. Expected taps
+   * will probably be ~2-8, with the goal of having the lowest smooth value.
+   * 
+   */
+  public IMUVelocity(SwerveIMU gyro, double periodSeconds, int averagingTaps)
+  {
+    this.gyro = gyro;
+    velocityFilter = LinearFilter.movingAverage(averagingTaps);
+    notifier = new Notifier(this::update);
+    notifier.startPeriodic(periodSeconds);
+    timestamp = RobotController.getFPGATime();
+  }
+
+  /**
+   * Update the robot's rotational velocity based on the current gyro position.
+   */
+  private void update() 
+  {
+    double newTimestamp = RobotController.getFPGATime();
+    Rotation2d newPosition = Rotation2d.fromRadians(gyro.getRotation3d().getZ());
+
+    synchronized (this) {
+      if (!firstCycle) {
+        velocity = velocityFilter.calculate(
+            (newPosition.minus(position).getRadians()) / (newTimestamp - timestamp));
+        }
+      firstCycle = false;
+      timestamp = newTimestamp;
+      position = newPosition;
+    }
+  }
+
+  /**
+   * Get the robot's angular velocity based on averaged meaasurements from the IMU.
+   *
+   * @return robot's angular velocity in rads/s as a double.
+   */
+  public synchronized double getVelocity() {
+    return velocity;
+  }
+}

--- a/src/main/java/swervelib/imu/IMUVelocity.java
+++ b/src/main/java/swervelib/imu/IMUVelocity.java
@@ -1,9 +1,9 @@
 package swervelib.imu;
 
+import edu.wpi.first.hal.HALUtil;
 import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.Notifier;
-import edu.wpi.first.wpilibj.RobotController;
 
 public class IMUVelocity {
   /**
@@ -66,7 +66,7 @@ public class IMUVelocity {
     velocityFilter = LinearFilter.movingAverage(averagingTaps);
     notifier = new Notifier(this::update);
     notifier.startPeriodic(periodSeconds);
-    timestamp = RobotController.getFPGATime();
+    timestamp = HALUtil.getFPGATime();
   }
 
   /**
@@ -74,7 +74,7 @@ public class IMUVelocity {
    */
   private void update() 
   {
-    double newTimestamp = RobotController.getFPGATime();
+    double newTimestamp = HALUtil.getFPGATime();
     Rotation2d newPosition = Rotation2d.fromRadians(gyro.getRotation3d().getZ());
 
     synchronized (this) {

--- a/src/main/java/swervelib/math/SwerveMath.java
+++ b/src/main/java/swervelib/math/SwerveMath.java
@@ -136,7 +136,7 @@ public class SwerveMath
   public static double calculateMaxAngularVelocity(
       double maxSpeed, double furthestModuleX, double furthestModuleY)
   {
-    return maxSpeed / new Rotation2d(furthestModuleX, furthestModuleY).getRadians();
+    return maxSpeed / Math.hypot(furthestModuleX, furthestModuleY);
   }
 
   /**


### PR DESCRIPTION
This PR contains my previous change to the calculation of the robot's max angular velocity. Instead of using a Rotation2D for the radius, which produced a value on a unit circle, we now use the hypot which gives us the correct distance to the furthest swerve.

Additionally it contains angular velocity correction, found in 2910's code, which seems to significantly reduce skew, especially when rotating quickly. From my testing this correction scales beautifully with angular velocity, the same cannot be said for discretize. I haven't done testing with angular velocity correction without discretize. When testing discretize with a multiplier to the input angular velocity we could find a value that would reduce skew nearly to 0 at a specific translational and rotational speed but skew was still visually poor at other speeds under the same multiplier. Here is the code used for the testing done with discretize that did not produce favorable results:

![image](https://github.com/user-attachments/assets/ea5e8767-8929-4a9d-88ca-c695dda5e0c4)

Still haven't gotten around to doing the math and creating a full explanation but this the code should be sufficient for testing. I plan on finishing the comments and an explanation hopefully this week but don't want that to get in the way of testing. The details for tuning are documented in the angularVelocityCoeff portion of the setAngularVelocityCompensation method: 

"The angular velocity coefficient. Expected values between -0.15 to 0.15, although higher values may be needed.

Start with a value of 0.1.

When enabling for the first time if the skew is significantly worse try inverting the value.

Tune by moving in a straight line while rotating. Change the value until you are visually happy with the skew. Ensure your tune works with different translational and rotational magnitudes."

Still haven't gotten the chance to analyze performance. Additionally I need to figure out the update rate for other IMUs, my current assumption is 60hz is ok but I couldn't exactly find the rate for the ADIS and ADXRS IMUs. There are comments that make me think they update at ~200hz but I am not 100% sure. It could be critical that the Notifier's period is slower or equal to the IMU's update rate. (in other words we want the IMU to have a new value every Notifier period)

I didn't add the change to discretize's timestep to use  HALUtil.getFPGATime() / 1.0e6, I may add that as a revision or separate PR.

Additionally I added setChassisSpeedsWithDriveOptimizations(ChassisSpeeds chassisSpeeds) which could be used with pathplanner. I should probably allow users to turn off each auto specific optimizations but I believe if you correct your skew in teleop, then those optimizations should be present in auto. The explanation my students and I landed on, is an analogy to the gravitational constant in the feedfoward of an arm/elevator. We know that arm is effected by gravity and with our feedforward we are able to reduce the amount of work the PID does to keep the arm up. We believe the same should be true for the drive optimizations in auto, if we can make the robot skew less then the pathplanner PID should have to do less work. We are super happy with optimizations in auto via our testing (although we have not done a ton of testing). It might not need to be the default but may be nice for teams to try. We found that our PID values did not require changing but that may not be true for other teams.