### PR TITLE
A tiny bug fix in the aim-at-speaker command of the example swerve subsystem code

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -228,7 +228,7 @@ public class SwerveSubsystem extends SubsystemBase
                                                                                   getSpeakerYaw().getRadians()),
                                                       getHeading())
                );
-        }).until(() -> getSpeakerYaw().minus(getHeading()).getDegrees() < tolerance);
+        }).until(() -> Math.abs(getSpeakerYaw().minus(getHeading()).getDegrees()) < tolerance);
   }
 
   /**


### PR DESCRIPTION
When judging whether the rotation error is within the tolerance, we should use the absolute value of the difference, since the difference might be negative.