### PR TITLE
AHRS imu variable is lost after constructor scope ends

### DIFF
--- a/src/main/java/swervelib/imu/NavXSwerve.java
+++ b/src/main/java/swervelib/imu/NavXSwerve.java
@@ -41,7 +41,6 @@ public class NavXSwerve extends SwerveIMU
     navXError = new Alert("IMU", "Error instantiating NavX.", AlertType.kError);
     try
     {
-      AHRS
           /* Communicate w/navX-MXP via the MXP SPI Bus.                                     */
           /* Alternatively:  I2C.Port.kMXP, SerialPort.Port.kMXP or SerialPort.Port.kUSB     */
           /* See http://navx-mxp.kauailabs.com/guidance/selecting-an-interface/ for details. */


### PR DESCRIPTION
When testing this on my robot with a NavX, I discovered that the imu is never retained after the constructor loses scope.