### PR TITLE
Add a chooser to set drive mode

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -48,10 +48,10 @@ public class RobotContainer
                                                                                                OperatorConstants.LEFT_X_DEADBAND),
                                                                  () -> -MathUtil.applyDeadband(driverXbox.getRightX(),
                                                                                                OperatorConstants.RIGHT_X_DEADBAND),
-                                                                 driverXbox.getHID()::getYButtonPressed,
-                                                                 driverXbox.getHID()::getAButtonPressed,
-                                                                 driverXbox.getHID()::getXButtonPressed,
-                                                                 driverXbox.getHID()::getBButtonPressed);
+                                                                 ()-> (driverXbox.getHID().getPOV() == 0),
+                                                                 ()-> (driverXbox.getHID().getPOV() == 180),
+                                                                 ()-> (driverXbox.getHID().getPOV() == 90),
+                                                                 ()-> (driverXbox.getHID().getPOV() == 270));
 
   // Applies deadbands and inverts controls because joysticks
   // are back-right positive while robot
@@ -59,10 +59,10 @@ public class RobotContainer
   // left stick controls translation
   // right stick controls the desired angle NOT angular rotation
   Command driveFieldOrientedDirectAngle = drivebase.driveCommand(
-      () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
-      () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
-      () -> driverXbox.getRightX(),
-      () -> driverXbox.getRightY());
+      () -> MathUtil.applyDeadband(driverXbox.getLeftY() * -1, OperatorConstants.LEFT_Y_DEADBAND),
+      () -> MathUtil.applyDeadband(driverXbox.getLeftX() * -1, OperatorConstants.LEFT_X_DEADBAND),
+      () -> driverXbox.getRightX() * -1,
+      () -> driverXbox.getRightY() * -1);
 
   // Applies deadbands and inverts controls because joysticks
   // are back-right positive while robot

--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
@@ -82,7 +82,7 @@ public class AbsoluteDriveAdv extends Command
     // Face Away from Drivers
     if (lookAway.getAsBoolean())
     {
-      headingY = -1;
+      headingY = 1;
     }
     // Face Right
     if (lookRight.getAsBoolean())
@@ -97,7 +97,7 @@ public class AbsoluteDriveAdv extends Command
     // Face Towards the Drivers
     if (lookTowards.getAsBoolean())
     {
-      headingY = 1;
+      headingY = -1;
     }
 
     // Prevent Movement After Auto
@@ -130,7 +130,7 @@ public class AbsoluteDriveAdv extends Command
     if (headingX == 0 && headingY == 0 && Math.abs(headingAdjust.getAsDouble()) > 0)
     {
       resetHeading = true;
-      swerve.drive(translation, (Constants.OperatorConstants.TURN_CONSTANT * -headingAdjust.getAsDouble()), true);
+      swerve.drive(translation, (Constants.OperatorConstants.TURN_CONSTANT * headingAdjust.getAsDouble()), true);
     } else
     {
       swerve.drive(translation, desiredSpeeds.omegaRadiansPerSecond, true);

--- a/src/main/java/swervelib/math/SwerveMath.java
+++ b/src/main/java/swervelib/math/SwerveMath.java
@@ -399,6 +399,10 @@ public class SwerveMath
    */
   public static Translation2d cubeTranslation(Translation2d translation)
   {
+    if (Math.hypot(translation.getX(), translation.getY()) <= 1.0E-6)
+    {
+      return translation;
+    }
     return new Translation2d(Math.pow(translation.getNorm(), 3), translation.getAngle());
   }
 


### PR DESCRIPTION
A SendableChooser is added to the RobotContainer that allows the drive mode command to be selected from a dashboard at runtime. The setDriveMode function is called in testInit and teleopInit so the chooser is checked and the default drive command is updated when the robot is enabled in either mode. This chooser is intended as a convenient way to try out different drive modes in YAGSL for testing, training and swerve familiarization and isn't intended for comp software.