### PR TITLE
Rename SwerveDrive.resetOdometry() to SwerveDrive.setPose()

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -587,7 +587,7 @@ public class SwerveSubsystem extends SubsystemBase
    */
   public void resetOdometry(Pose2d initialHolonomicPose)
   {
-    swerveDrive.resetOdometry(initialHolonomicPose);
+    swerveDrive.setPose(initialHolonomicPose);
   }
 
   /**

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -859,13 +859,24 @@ public class SwerveDrive
   }
 
   /**
+   * Resets odometry to the given pose.
+   * 
+   * @param pose
+   * @deprecated Renaming to {@link #setPose(Pose2d)}
+   */
+  @Deprecated
+  public void resetOdometry(Pose2d pose) {
+    setPose(pose);
+  }
+
+  /**
    * Resets odometry to the given pose. Gyro angle and module positions do not need to be reset when calling this
    * method. However, if either gyro angle or module position is reset, this must be called in order for odometry to
    * keep working.
    *
    * @param pose The pose to set the odometry to
    */
-  public void resetOdometry(Pose2d pose)
+  public void setPose(Pose2d pose)
   {
     odometryLock.lock();
     swerveDrivePoseEstimator.resetPosition(getYaw(), getModulePositions(), pose);
@@ -877,7 +888,6 @@ public class SwerveDrive
     ChassisSpeeds robotRelativeSpeeds = new ChassisSpeeds();
     robotRelativeSpeeds.toFieldRelativeSpeeds(getYaw());
     kinematics.toSwerveModuleStates(robotRelativeSpeeds);
-
   }
 
   /**

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -979,7 +979,7 @@ public class SwerveDrive
     imuReadingCache.update();
     swerveController.lastAngleScalar = 0;
     lastHeadingRadians = 0;
-    resetOdometry(new Pose2d(getPose().getTranslation(), new Rotation2d()));
+    setPose(new Pose2d(getPose().getTranslation(), new Rotation2d()));
   }
 
   /**
@@ -1307,7 +1307,7 @@ public class SwerveDrive
     odometryLock.unlock();
 
 //    setGyroOffset(new Rotation3d(0, 0, robotPose.getRotation().getRadians()));
-//    resetOdometry(newOdometry);
+//    setPose(newOdometry);
   }
 
   /**


### PR DESCRIPTION
I think the name setPose() is better for this function. Realistically, nearly everybody who is going to use YAGSL is going to be hooking it up to PathPlannerLib. PathPlannerLib's function [AutoBuilder.configure()](https://pathplanner.dev/api/java/com/pathplanner/lib/auto/AutoBuilder.html#configure(java.util.function.Supplier,java.util.function.Consumer,java.util.function.Supplier,java.util.function.Consumer,com.pathplanner.lib.controllers.PathFollowingController,com.pathplanner.lib.config.RobotConfig,java.util.function.BooleanSupplier,edu.wpi.first.wpilibj2.command.Subsystem...)) takes in a functionc called resetPose. One of my programmers came to me because he could not find how to route this through YAGSL because he could not find this function (Admittedly, this is a just-read-the-docs issue, but I think the point still stands).

Old function preserved in API so that this won't break any old code, but deprecation notices have been added.