### PR TITLE
Fix getMaxVelocity used in feedforward

### DIFF
--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -1,5 +1,6 @@
 package swervelib;
 
+import static edu.wpi.first.units.Units.InchesPerSecond;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
@@ -762,10 +763,10 @@ public class SwerveModule
   {
     if (maxDriveVelocity == null)
     {
-      maxDriveVelocity = MetersPerSecond.of(
-          (RadiansPerSecond.of(driveMotor.getSimMotor().freeSpeedRadPerSec).in(RotationsPerSecond) /
-           configuration.conversionFactors.drive.gearRatio) *
-          configuration.conversionFactors.drive.diameter);
+      maxDriveVelocity = InchesPerSecond.of(
+          (driveMotor.getSimMotor().freeSpeedRadPerSec /
+              configuration.conversionFactors.drive.gearRatio) *
+              configuration.conversionFactors.drive.diameter / 2.0);
     }
     return maxDriveVelocity;
   }


### PR DESCRIPTION
The max velocity used to create the drive motor feedforward does not correctly account for wheel circumference and conversion from inches to meters. This causes the velocity feedforward to be about 1/12 (3.14/39.7) of what it should be resulting in low drive speed.