### PR TITLE
Spinning mode for drive characterization 

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -348,7 +348,7 @@ public class SwerveSubsystem extends SubsystemBase
     return SwerveDriveTest.generateSysIdCommand(
         SwerveDriveTest.setDriveSysIdRoutine(
             new Config(),
-            this, swerveDrive, 12),
+            this, swerveDrive, 12, true),
         3.0, 5.0, 3.0);
   }
 

--- a/src/main/java/swervelib/simulation/SwerveModuleSimulation.java
+++ b/src/main/java/swervelib/simulation/SwerveModuleSimulation.java
@@ -48,7 +48,7 @@ public class SwerveModuleSimulation
 
   /**
    * Runs a drive motor characterization on the sim module.
-   * This is called from {@link swervelib.SwerveDriveTest#runDriveMotorsCharacterizationOnSimModules(SwerveDrive, double)}  to run sysId during simulation
+   * This is called from {@link swervelib.SwerveDriveTest#runDriveMotorsCharacterizationOnSimModules(SwerveDrive, double, boolean)}  to run sysId during simulation
    *
    * @param desiredFacing the desired facing of the module
    * @param volts the voltage to run


### PR DESCRIPTION
Added an alternative mode for drive motor characterization, where the robot spins in place instead of driving forward.

This feature should work on both simulated and real robots. I've tested it in simulation but not on real robot yet.