### PR TITLE
Null pointer crash when there have been no vision results

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -394,7 +394,8 @@ public class Vision
     /**
      * Estimated robot pose.
      */
-    public        Optional<EstimatedRobotPose> estimatedRobotPose;
+    public        Optional<EstimatedRobotPose> estimatedRobotPose = Optional.empty();
+
     /**
      * Simulated camera instance which only exists during simulations.
      */


### PR DESCRIPTION
When there have been no results from the vision cameras and updatePoseEstimation() is called, a null pointer causes the code to crash. This can happen if the coprocessor is off or none of the cameras see tags when the code starts up.