### PR TITLE
Update AprilTagFields to 2025

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -66,7 +66,7 @@ public class SwerveSubsystem extends SubsystemBase
   /**
    * AprilTag field layout.
    */
-  private final AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
+  private final AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
   /**
    * Enable vision odometry updates while driving.
    */


### PR DESCRIPTION
Updated AprilTagFields in the SwerveSubsystem to ReefScape2025. This now matches the field in the Vision subsystem. However, it doesn't appear that the AprilTagField is actually used in the SwerveSubsystem, so it might also be best to delete it.