### PR TITLE
Add optional optimization of module states in drive function that uses feedforward

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -766,12 +766,8 @@ public class SwerveDrive
     }
     for (SwerveModule module : swerveModules)
     {
-      // SwerveModuleState optimization might be desired to be disabled while debugging.
-      if (module.getModuleStateOptimization())
-      {
-        states[module.moduleNumber].optimize(Rotation2d.fromDegrees(module.getAbsolutePosition()));
-        module.applyAntiJitter(states[module.moduleNumber], false);
-      }
+      module.applyStateOptimizations(states[module.moduleNumber]);
+      module.applyAntiJitter(states[module.moduleNumber], false);
       
       // from the module configuration, obtain necessary information to calculate feed-forward
       // Warning: Will not work well if motor is not what we are expecting.

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -770,6 +770,7 @@ public class SwerveDrive
       if (module.getModuleStateOptimization())
       {
         states[module.moduleNumber].optimize(Rotation2d.fromDegrees(module.getAbsolutePosition()));
+        module.applyAntiJitter(states[module.moduleNumber], false);
       }
       
       // from the module configuration, obtain necessary information to calculate feed-forward

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -766,6 +766,12 @@ public class SwerveDrive
     }
     for (SwerveModule module : swerveModules)
     {
+      // SwerveModuleState optimization might be desired to be disabled while debugging.
+      if (module.getModuleStateOptimization())
+      {
+        states[module.moduleNumber].optimize(Rotation2d.fromDegrees(module.getAbsolutePosition()));
+      }
+      
       // from the module configuration, obtain necessary information to calculate feed-forward
       // Warning: Will not work well if motor is not what we are expecting.
       // Warning: Should replace module.getDriveMotor().simMotor with expected motor type first.

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -291,6 +291,11 @@ public class SwerveModule
     optimizeSwerveModuleState = optimizationState;
   }
 
+  /**
+   * Check if the module state optimization used by {@link SwerveModuleState#optimize(Rotation2d)} is enabled.
+   *
+   * @return optimization state.
+   */
   public boolean getModuleStateOptimization() {
     return optimizeSwerveModuleState;
   }
@@ -469,7 +474,6 @@ public class SwerveModule
   public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop,
                               double driveFeedforwardVoltage)
   {
-    
     if (isOpenLoop)
     {
       double percentOutput = desiredState.speedMetersPerSecond / maxDriveVelocity.in(MetersPerSecond);

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -551,6 +551,15 @@ public class SwerveModule
     return desiredState.speedMetersPerSecond * cosineScalar;
   }
 
+  public void applyAntiJitter(SwerveModuleState desiredState, boolean force) 
+  {
+    if (!force && antiJitterEnabled)
+    {
+      // Prevents module rotation if speed is less than 1%
+      SwerveMath.antiJitter(desiredState, lastState, Math.min(maxDriveVelocityMetersPerSecond, 4));
+    }
+  }
+
   /**
    * Set the angle for the module.
    *

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -291,6 +291,10 @@ public class SwerveModule
     optimizeSwerveModuleState = optimizationState;
   }
 
+  public boolean getModuleStateOptimization() {
+    return optimizeSwerveModuleState;
+  }
+
   /**
    * Set the voltage compensation for the swerve module motor.
    *
@@ -465,11 +469,6 @@ public class SwerveModule
   public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop,
                               double driveFeedforwardVoltage)
   {
-    // SwerveModuleState optimization might be desired to be disabled while debugging.
-    if (optimizeSwerveModuleState)
-    {
-      desiredState.optimize(Rotation2d.fromDegrees(getAbsolutePosition()));
-    }
     
     if (isOpenLoop)
     {

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -465,7 +465,12 @@ public class SwerveModule
   public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop,
                               double driveFeedforwardVoltage)
   {
-
+    // SwerveModuleState optimization might be desired to be disabled while debugging.
+    if (optimizeSwerveModuleState)
+    {
+      desiredState.optimize(Rotation2d.fromDegrees(getAbsolutePosition()));
+    }
+    
     if (isOpenLoop)
     {
       double percentOutput = desiredState.speedMetersPerSecond / maxDriveVelocity.in(MetersPerSecond);

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -437,18 +437,8 @@ public class SwerveModule
    */
   public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop, boolean force)
   {
-    // SwerveModuleState optimization might be desired to be disabled while debugging.
-    if (optimizeSwerveModuleState)
-    {
-      desiredState.optimize(Rotation2d.fromDegrees(getAbsolutePosition()));
-    }
-
-    // If we are forcing the angle
-    if (!force && antiJitterEnabled)
-    {
-      // Prevents module rotation if speed is less than 1%
-      SwerveMath.antiJitter(desiredState, lastState, Math.min(maxDriveVelocityMetersPerSecond, 4));
-    }
+    applyStateOptimizations(desiredState);
+    applyAntiJitter(desiredState, force);
 
     // Cosine compensation.
     double nextVelocityMetersPerSecond = configuration.useCosineCompensator
@@ -551,6 +541,29 @@ public class SwerveModule
     return desiredState.speedMetersPerSecond * cosineScalar;
   }
 
+  /**
+   * Apply the {@link SwerveModuleState#optimize(Rotation2d)} function if the module state optimization is enabled
+   * while debugging.
+   *
+   * @param desiredState The desired state to apply the optimization to.
+   */
+  public void applyStateOptimizations(SwerveModuleState desiredState) 
+  {
+    // SwerveModuleState optimization might be desired to be disabled while debugging.
+    if (optimizeSwerveModuleState)
+    {
+      desiredState.optimize(Rotation2d.fromDegrees(getAbsolutePosition()));
+    }    
+  }
+  
+  /**
+   * Apply anti-jitter to the desired state. This will prevent the module from rotating if the speed requested is
+   * too low. If force is true, the anti-jitter will not be applied.
+   *
+   * @param desiredState The desired state to apply the anti-jitter to.
+   * @param force         Whether to ignore the {@link SwerveModule#antiJitterEnabled} state and apply the anti-jitter
+   *                      anyway.
+   */
   public void applyAntiJitter(SwerveModuleState desiredState, boolean force) 
   {
     if (!force && antiJitterEnabled)


### PR DESCRIPTION
We had been calling optimize on our module states before using the drive function that uses feedforward from PathPlanner and seeing that you made this an optional choice in the other cases, it made sense to also include it for autos. We have tested this change on our robot. 