### PR TITLE
Remove aprilTagFieldLayout from SwerveSubsystem

### DIFF
--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -64,10 +64,6 @@ public class SwerveSubsystem extends SubsystemBase
    */
   private final SwerveDrive         swerveDrive;
   /**
-   * AprilTag field layout.
-   */
-  private final AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadField(AprilTagFields.k2024Crescendo);
-  /**
    * Enable vision odometry updates while driving.
    */
   private final boolean             visionDriveTest     = false;


### PR DESCRIPTION
It already exists in `Vision.java` and is not used in any commented-out code either

This is also discussed in #313, but I am creating a new PR due to the inactivity.