### PR TITLE
Make all closable items implement  `AutoClosable`

### DIFF
--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -337,8 +337,9 @@ public class SwerveDrive implements AutoCloseable
   @Override
   public void close() {
     imu.close();
+    tunerXRecommendation.close();
 
-    for (var module : swerveDriveConfiguration.modules) {
+    for (var module : swerveModules) {
       module.close();
     }
   }

--- a/src/main/java/swervelib/SwerveDrive.java
+++ b/src/main/java/swervelib/SwerveDrive.java
@@ -71,7 +71,7 @@ import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 /**
  * Swerve Drive class representing and controlling the swerve drive.
  */
-public class SwerveDrive
+public class SwerveDrive implements AutoCloseable
 {
 
   /**
@@ -332,6 +332,15 @@ public class SwerveDrive
     checkIfTunerXCompatible();
 
     HAL.report(kResourceType_RobotDrive, kRobotDriveSwerve_YAGSL);
+  }
+
+  @Override
+  public void close() {
+    imu.close();
+
+    for (var module : swerveDriveConfiguration.modules) {
+      module.close();
+    }
   }
 
   /**

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -269,9 +269,9 @@ public class SwerveModule implements AutoCloseable
 
   @Override
   public void close() {
-    configuration.angleMotor.close();
-    configuration.driveMotor.close();
-    configuration.absoluteEncoder.close();
+    angleMotor.close();
+    driveMotor.close();
+    absoluteEncoder.close();
   }
 
   /**

--- a/src/main/java/swervelib/SwerveModule.java
+++ b/src/main/java/swervelib/SwerveModule.java
@@ -34,7 +34,7 @@ import swervelib.telemetry.SwerveDriveTelemetry.TelemetryVerbosity;
 /**
  * The Swerve Module class which represents and controls Swerve Modules for the swerve drive.
  */
-public class SwerveModule
+public class SwerveModule implements AutoCloseable
 {
 
   /**
@@ -265,6 +265,13 @@ public class SwerveModule
         "swerve/modules/" + configuration.name + "/Speed Setpoint").publish();
     angleSetpointPublisher = NetworkTableInstance.getDefault().getTable("SmartDashboard").getDoubleTopic(
         "swerve/modules/" + configuration.name + "/Angle Setpoint").publish();
+  }
+
+  @Override
+  public void close() {
+    configuration.angleMotor.close();
+    configuration.driveMotor.close();
+    configuration.absoluteEncoder.close();
   }
 
   /**

--- a/src/main/java/swervelib/encoders/AnalogAbsoluteEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/AnalogAbsoluteEncoderSwerve.java
@@ -47,6 +47,12 @@ public class AnalogAbsoluteEncoderSwerve extends SwerveAbsoluteEncoder
         AlertType.kWarning);
   }
 
+  @Override
+  public void close()
+  {
+    encoder.close();
+  }
+
   /**
    * Construct the Encoder given the analog input channel.
    *

--- a/src/main/java/swervelib/encoders/CANCoderSwerve.java
+++ b/src/main/java/swervelib/encoders/CANCoderSwerve.java
@@ -112,6 +112,12 @@ public class CANCoderSwerve extends SwerveAbsoluteEncoder
         AlertType.kWarning);
   }
 
+  @Override
+  public void close()
+  {
+    encoder.close();
+  }
+
   /**
    * Reset the encoder to factory defaults.
    */

--- a/src/main/java/swervelib/encoders/CanAndMagSwerve.java
+++ b/src/main/java/swervelib/encoders/CanAndMagSwerve.java
@@ -29,6 +29,12 @@ public class CanAndMagSwerve extends SwerveAbsoluteEncoder
     settings = encoder.getSettings();
   }
 
+  @Override
+  public void close() 
+  {
+    encoder.close();
+  }
+
   /**
    * Reset the encoder to factory defaults.
    * <p>

--- a/src/main/java/swervelib/encoders/DIODutyCycleEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/DIODutyCycleEncoderSwerve.java
@@ -47,6 +47,12 @@ public class DIODutyCycleEncoderSwerve extends SwerveAbsoluteEncoder
 
   }
 
+  @Override
+  public void close()
+  {
+    encoder.close();
+  }
+
   /**
    * Configure the inversion state of the encoder.
    *

--- a/src/main/java/swervelib/encoders/SparkFlexEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/SparkFlexEncoderSwerve.java
@@ -62,6 +62,15 @@ public class SparkFlexEncoderSwerve extends SwerveAbsoluteEncoder
     }
   }
 
+  @Override
+  public void close()
+  {
+    // SPARK Flex encoder gets closed with the motor
+    // I don't think an encoder getting closed should 
+    // close the entire motor so i will keep this empty
+    // sparkFlex.close();
+  }
+
   /**
    * Run the configuration until it succeeds or times out.
    *

--- a/src/main/java/swervelib/encoders/SparkMaxAnalogEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/SparkMaxAnalogEncoderSwerve.java
@@ -64,6 +64,15 @@ public class SparkMaxAnalogEncoderSwerve extends SwerveAbsoluteEncoder
 
   }
 
+  @Override
+  public void close()
+  {
+    // SPARK MAX Analog encoder gets closed with the motor
+    // I don't think an encoder getting closed should 
+    // close the entire motor so i will keep this empty
+    // sparkMax.close();
+  }
+
   /**
    * Run the configuration until it succeeds or times out.
    *

--- a/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
@@ -64,6 +64,15 @@ public class SparkMaxEncoderSwerve extends SwerveAbsoluteEncoder
     }
   }
 
+  @Override
+  public void close()
+  {
+    // SPARK MAX encoder gets closed with the motor
+    // I don't think an encoder getting closed should 
+    // close the entire motor so i will keep this empty
+    // sparkFlex.close();
+  }
+
   /**
    * Run the configuration until it succeeds or times out.
    *

--- a/src/main/java/swervelib/encoders/SwerveAbsoluteEncoder.java
+++ b/src/main/java/swervelib/encoders/SwerveAbsoluteEncoder.java
@@ -3,8 +3,14 @@ package swervelib.encoders;
 /**
  * Swerve abstraction class to define a standard interface with absolute encoders for swerve modules..
  */
-public abstract class SwerveAbsoluteEncoder
+public abstract class SwerveAbsoluteEncoder implements AutoCloseable
 {
+
+  // This is a bit weird because some encoders are closable 
+  // while some get closed with the motor controller
+  // so for some encoders this will be an empty function
+  @Override
+  public abstract void close();
 
   /**
    * The maximum amount of times the swerve encoder will attempt to configure itself if failures occur.

--- a/src/main/java/swervelib/encoders/TalonSRXEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/TalonSRXEncoderSwerve.java
@@ -45,6 +45,15 @@ public class TalonSRXEncoderSwerve extends SwerveAbsoluteEncoder
   }
 
   @Override
+  public void close()
+  {
+    // TalonSRX encoder gets closed with the motor
+    // I don't think an encoder getting closed should 
+    // close the entire motor so i will keep this empty
+    // sparkFlex.close();
+  }
+
+  @Override
   public void factoryDefault()
   {
     // Handled in TalonSRXSwerve

--- a/src/main/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
@@ -34,6 +34,15 @@ public class ThriftyNovaEncoderSwerve extends SwerveAbsoluteEncoder
     motor.setAbsoluteEncoder(null);
   }
 
+  @Override
+  public void close()
+  {
+    // ThriftyNova encoder gets closed with the motor
+    // I don't think an encoder getting closed should 
+    // close the entire motor so i will keep this empty
+    // sparkFlex.close();
+  }
+
   /**
    * Set factory default.
    */

--- a/src/main/java/swervelib/imu/ADIS16448Swerve.java
+++ b/src/main/java/swervelib/imu/ADIS16448Swerve.java
@@ -42,6 +42,11 @@ public class ADIS16448Swerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/ADIS16470Swerve.java
+++ b/src/main/java/swervelib/imu/ADIS16470Swerve.java
@@ -44,6 +44,11 @@ public class ADIS16470Swerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/ADXRS450Swerve.java
+++ b/src/main/java/swervelib/imu/ADXRS450Swerve.java
@@ -42,6 +42,11 @@ public class ADXRS450Swerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/AnalogGyroSwerve.java
+++ b/src/main/java/swervelib/imu/AnalogGyroSwerve.java
@@ -49,6 +49,11 @@ public class AnalogGyroSwerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/NavXSwerve.java
+++ b/src/main/java/swervelib/imu/NavXSwerve.java
@@ -60,6 +60,10 @@ public class NavXSwerve extends SwerveIMU
     }
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
 
   /**
    * Reset offset to current gyro reading. Does not call NavX({@link AHRS#reset()}) because it has been reported to be

--- a/src/main/java/swervelib/imu/Pigeon2Swerve.java
+++ b/src/main/java/swervelib/imu/Pigeon2Swerve.java
@@ -85,6 +85,12 @@ public class Pigeon2Swerve extends SwerveIMU
     this(canid, "");
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
+
   /**
    * Reset {@link Pigeon2} to factory default.
    */

--- a/src/main/java/swervelib/imu/PigeonSwerve.java
+++ b/src/main/java/swervelib/imu/PigeonSwerve.java
@@ -45,6 +45,12 @@ public class PigeonSwerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/PigeonViaTalonSRXSwerve.java
+++ b/src/main/java/swervelib/imu/PigeonViaTalonSRXSwerve.java
@@ -54,6 +54,11 @@ public class PigeonViaTalonSRXSwerve extends SwerveIMU
     SmartDashboard.putData(imu);
   }
 
+  @Override
+  public void close() {
+    imu.close();
+  }
+
   /**
    * Reset IMU to factory default.
    */

--- a/src/main/java/swervelib/imu/SwerveIMU.java
+++ b/src/main/java/swervelib/imu/SwerveIMU.java
@@ -8,8 +8,11 @@ import java.util.Optional;
 /**
  * Swerve IMU abstraction to define a standard interface with a swerve drive.
  */
-public abstract class SwerveIMU
+public abstract class SwerveIMU implements AutoCloseable
 {
+
+  @Override
+  public abstract void close();
 
   /**
    * Reset IMU to factory default.

--- a/src/main/java/swervelib/motors/SparkFlexSwerve.java
+++ b/src/main/java/swervelib/motors/SparkFlexSwerve.java
@@ -129,6 +129,11 @@ public class SparkFlexSwerve extends SwerveMotor
     failureConfiguring.set(true);
   }
 
+  @Override
+  public void close() {
+    motor.close();
+  }
+
   /**
    * Get the current configuration of the {@link SparkFlex}
    *

--- a/src/main/java/swervelib/motors/SparkMaxBrushedMotorSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxBrushedMotorSwerve.java
@@ -195,6 +195,11 @@ public class SparkMaxBrushedMotorSwerve extends SwerveMotor
     failureConfiguringAlert.set(true);
   }
 
+  @Override
+  public void close() {
+    motor.close();
+  }
+
   /**
    * Get the current configuration of the {@link SparkMax}
    *

--- a/src/main/java/swervelib/motors/SparkMaxSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxSwerve.java
@@ -127,6 +127,11 @@ public class SparkMaxSwerve extends SwerveMotor
     DriverStation.reportWarning("Failure configuring motor " + motor.getDeviceId(), true);
   }
 
+  @Override
+  public void close() {
+    motor.close();
+  }
+
   /**
    * Get the current configuration of the {@link SparkMax}
    *

--- a/src/main/java/swervelib/motors/SwerveMotor.java
+++ b/src/main/java/swervelib/motors/SwerveMotor.java
@@ -7,8 +7,11 @@ import swervelib.parser.PIDFConfig;
 /**
  * Swerve motor abstraction which defines a standard interface for motors within a swerve module.
  */
-public abstract class SwerveMotor
+public abstract class SwerveMotor implements AutoCloseable
 {
+
+  @Override
+  public abstract void close();
 
   /**
    * The maximum amount of times the swerve motor will attempt to configure a motor if failures occur.

--- a/src/main/java/swervelib/motors/TalonFXSwerve.java
+++ b/src/main/java/swervelib/motors/TalonFXSwerve.java
@@ -131,6 +131,12 @@ public class TalonFXSwerve extends SwerveMotor
     }
   }
 
+  @Override
+  public void close() {
+    motor.close();
+  }
+
+
   /**
    * Clear the sticky faults on the motor controller.
    */

--- a/src/main/java/swervelib/motors/TalonSRXSwerve.java
+++ b/src/main/java/swervelib/motors/TalonSRXSwerve.java
@@ -84,6 +84,11 @@ public class TalonSRXSwerve extends SwerveMotor
     this(new WPI_TalonSRX(id), isDriveMotor, motorType);
   }
 
+  @Override
+  public void close() {
+    motor.close();
+  }
+
   /**
    * Configure the factory defaults.
    */

--- a/src/main/java/swervelib/motors/ThriftyNovaSwerve.java
+++ b/src/main/java/swervelib/motors/ThriftyNovaSwerve.java
@@ -105,6 +105,16 @@ public class ThriftyNovaSwerve extends SwerveMotor
     this(new ThriftyNova(id), isDriveMotor, motor);
   }
 
+  @Override
+  public void close() {
+    try {
+    motor.close();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
   /**
    * Set factory defaults on the motor controller.
    */


### PR DESCRIPTION
**This is for unit testing support in the future**

Implements `AutoClosable` on all `IMUs, `Motors` and **_Some_** `Encoders`

Encoder Exceptions:
- SparkFlexEncoder
- SparkMaxEncoder
- TalonSRXEncoder
- ThriftyNovaEncoder


Due to these encoders being closed with the motors themselves and not implementing `AutoClosable` themselves, they have an empty comment explaining that in their close method