### PR TITLE
stop setMotorBrake from constantly executing

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -82,7 +82,7 @@ public class Robot extends TimedRobot
     disabledTimer.reset();
     disabledTimer.start();
   }
-
+  
   @Override
   public void disabledPeriodic()
   {
@@ -90,6 +90,7 @@ public class Robot extends TimedRobot
     {
       m_robotContainer.setMotorBrake(false);
       disabledTimer.stop();
+      disabledTimer.reset();
     }
   }
 


### PR DESCRIPTION
Because setMotorBrake is constantly executing, it is making roboRIO CPU go to 75-80% and get tons of Command Scheduler Loop Overrun messages