### PR TITLE
Set ThriftyNova External Encoder type from config file choice

### DIFF
--- a/src/main/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
@@ -5,6 +5,7 @@ import com.thethriftybot.Conversion.PositionUnit;
 import com.thethriftybot.Conversion.VelocityUnit;
 import com.thethriftybot.ThriftyNova;
 import com.thethriftybot.ThriftyNova.EncoderType;
+import com.thethriftybot.ThriftyNova.ExternalEncoder;
 
 import swervelib.motors.SwerveMotor;
 import swervelib.motors.ThriftyNovaSwerve;
@@ -42,11 +43,12 @@ public class ThriftyNovaEncoderSwerve extends SwerveAbsoluteEncoder
    *
    * @param motor {@link SwerveMotor} through which to interface with the attached encoder .
    */
-  public ThriftyNovaEncoderSwerve(SwerveMotor motor)
+  public ThriftyNovaEncoderSwerve(SwerveMotor motor, String encoderType)
   {
     this.motor = (ThriftyNova) motor.getMotor();
     positionConversion = new Conversion(PositionUnit.DEGREES, EncoderType.ABS);
     velocityConversion = new Conversion(VelocityUnit.DEGREES_PER_SEC, EncoderType.ABS);
+    this.motor.setExternalEncoder(ExternalEncoder.valueOf(encoderType));
     this.motor.useEncoderType(EncoderType.ABS);
   }
 

--- a/src/main/java/swervelib/parser/json/DeviceJson.java
+++ b/src/main/java/swervelib/parser/json/DeviceJson.java
@@ -111,11 +111,21 @@ public class DeviceJson
         return new TalonSRXEncoderSwerve(motor, FeedbackDevice.PulseWidthEncodedPosition);
       case "talonsrx_analog":
         return new TalonSRXEncoderSwerve(motor, FeedbackDevice.Analog);
-      case "thrifty_nova":
+      case "thrifty_nova_rev":
         return ReflectionsManager.<SwerveAbsoluteEncoder>create(VENDOR.THRIFTYBOT,
-                                                                "com.thethriftybot.ThriftyNova",
-                                                                new Class[]{SwerveMotor.class},
-                                                                new Object[]{motor});
+                                                                "swervelib.encoders.ThriftyNovaEncoderSwerve",
+                                                                new Class[]{SwerveMotor.class, String.class},
+                                                                new Object[]{motor, "REV_ENCODER"});
+      case "thrifty_nova_redux":
+        return ReflectionsManager.<SwerveAbsoluteEncoder>create(VENDOR.THRIFTYBOT,
+                                                                "swervelib.encoders.ThriftyNovaEncoderSwerve",
+                                                                new Class[]{SwerveMotor.class, String.class},
+                                                                new Object[]{motor, "REDUX_ENCODER"});
+      case "thrifty_nova_srx_mag":
+      return ReflectionsManager.<SwerveAbsoluteEncoder>create(VENDOR.THRIFTYBOT,
+                                                              "swervelib.encoders.ThriftyNovaEncoderSwerve",
+                                                              new Class[]{SwerveMotor.class, String.class},
+                                                              new Object[]{motor, "SRX_MAG_ENCODER"});
       default:
         throw new RuntimeException(type + " is not a recognized absolute encoder type.");
     }


### PR DESCRIPTION
Creates 3 config types for ThriftyNova external encoders that sets the correct type when being instantiated through reflection.
This was a response to a discussion on CD about needing to set the correct external encoder. Tested in simulation to ensure that they at least don't crash on startup.